### PR TITLE
View de initialize

### DIFF
--- a/Example-iOS/Source/UIkit/Layout.swift
+++ b/Example-iOS/Source/UIkit/Layout.swift
@@ -14,13 +14,10 @@ class LayoutView: UIView {
     var fitButtonAction: ButtonAction?
     var alignmentButtonAction: ButtonAction?
     
-    @IBOutlet var riveView: RiveView!
-    
-    
+    @IBOutlet weak var riveView: RiveView!
     @IBAction func fitButtonTriggered(_ sender: UIButton) {
         fitButtonAction?(sender.currentTitle!)
     }
-    
     @IBAction func alignmentButtonTriggered(_ sender: UIButton) {
         alignmentButtonAction?(sender.currentTitle!)
     }
@@ -58,6 +55,7 @@ class LayoutViewController: UIViewController {
             default:
                 fit = .fitContain
             }
+            
             layoutView.riveView.fit = fit
         }
         
@@ -95,5 +93,7 @@ class LayoutViewController: UIViewController {
     override public func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         (view as! LayoutView).riveView.stop()
+        (view as! LayoutView).fitButtonAction = nil
+        (view as! LayoutView).alignmentButtonAction = nil
     }
 }

--- a/Example-iOS/Source/UIkit/Layout.swift
+++ b/Example-iOS/Source/UIkit/Layout.swift
@@ -92,7 +92,6 @@ class LayoutViewController: UIViewController {
     
     override public func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        (view as! LayoutView).riveView.stop()
         (view as! LayoutView).fitButtonAction = nil
         (view as! LayoutView).alignmentButtonAction = nil
     }

--- a/Example-iOS/Source/UIkit/Layout.swift
+++ b/Example-iOS/Source/UIkit/Layout.swift
@@ -59,7 +59,7 @@ class LayoutViewController: UIViewController {
             layoutView.riveView.fit = fit
         }
         
-        func setAlignmnet(name:String) {
+        func setAlignmnet(name:String) { 
             var alignment: Alignment = .alignmentCenter
             switch name {
             case "Top Left":

--- a/Example-iOS/Source/UIkit/LoopMode.swift
+++ b/Example-iOS/Source/UIkit/LoopMode.swift
@@ -164,7 +164,6 @@ class LoopModeController: UIViewController {
     
     override public func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        (view as! LoopMode).riveView.stop()
         (view as! LoopMode).triggeredResetButton = nil
         (view as! LoopMode).triggeredForwardsButton = nil
         (view as! LoopMode).triggeredAutoButton = nil

--- a/Example-iOS/Source/UIkit/LoopMode.swift
+++ b/Example-iOS/Source/UIkit/LoopMode.swift
@@ -165,6 +165,25 @@ class LoopModeController: UIViewController {
     override public func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         (view as! LoopMode).riveView.stop()
+        (view as! LoopMode).triggeredResetButton = nil
+        (view as! LoopMode).triggeredForwardsButton = nil
+        (view as! LoopMode).triggeredAutoButton = nil
+        (view as! LoopMode).triggeredBackwardsButton = nil
+        
+        (view as! LoopMode).triggeredRotatePlayButton = nil
+        (view as! LoopMode).triggeredRotateOneShotButton = nil
+        (view as! LoopMode).triggeredRotateLoopButton = nil
+        (view as! LoopMode).triggeredRotatePingPongButton = nil
+        
+        (view as! LoopMode).triggeredLoopDownPlayButton = nil
+        (view as! LoopMode).triggeredLoopDownOneShotButton = nil
+        (view as! LoopMode).triggeredLoopDownLoopButton = nil
+        (view as! LoopMode).triggeredLoopDownPingPongButton = nil
+        
+        (view as! LoopMode).triggeredLtrPlayButton = nil
+        (view as! LoopMode).triggeredLtrLoopButton = nil
+        (view as! LoopMode).triggeredLtrOneShotButton = nil
+        (view as! LoopMode).triggeredLtrPingPongButton = nil
     }
 }
 

--- a/Example-iOS/Source/UIkit/MultipleAnimations.swift
+++ b/Example-iOS/Source/UIkit/MultipleAnimations.swift
@@ -17,6 +17,7 @@ class MultipleAnimations: UIView {
 }
 
 class MultipleAnimationsController: UIViewController {
+    
     let loopResourceName = "artboard_animations"
     
     override public func loadView() {

--- a/Example-iOS/Source/UIkit/MultipleAnimations.swift
+++ b/Example-iOS/Source/UIkit/MultipleAnimations.swift
@@ -49,10 +49,6 @@ class MultipleAnimationsController: UIViewController {
     
     override public func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        (view as! MultipleAnimations).squareGoAround.stop()
-        (view as! MultipleAnimations).squareRollAround.stop()
-        (view as! MultipleAnimations).circle.stop()
-        (view as! MultipleAnimations).star.stop()
         
     }
 }

--- a/Example-iOS/Source/UIkit/SimpleAnimation.swift
+++ b/Example-iOS/Source/UIkit/SimpleAnimation.swift
@@ -27,7 +27,7 @@ class SimpleAnimationViewController: UIViewController {
     
     override public func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        (view as! RiveView).stop()
+//        (view as! RiveView).stop()
     }
 }
 

--- a/Example-iOS/Source/UIkit/SimpleAnimation.swift
+++ b/Example-iOS/Source/UIkit/SimpleAnimation.swift
@@ -27,7 +27,6 @@ class SimpleAnimationViewController: UIViewController {
     
     override public func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-//        (view as! RiveView).stop()
     }
 }
 

--- a/Example-iOS/Source/UIkit/StateMachine.swift
+++ b/Example-iOS/Source/UIkit/StateMachine.swift
@@ -69,5 +69,8 @@ class StateMachineViewController: UIViewController {
     override public func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         (view as! StateMachineView).riveView.stop()
+        (view as! StateMachineView).beginnerButtonAction = nil
+        (view as! StateMachineView).intermediateButtonAction = nil
+        (view as! StateMachineView).expertButtonAction = nil
     }
 }

--- a/Example-iOS/Source/UIkit/StateMachine.swift
+++ b/Example-iOS/Source/UIkit/StateMachine.swift
@@ -68,7 +68,6 @@ class StateMachineViewController: UIViewController {
     
     override public func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        (view as! StateMachineView).riveView.stop()
         (view as! StateMachineView).beginnerButtonAction = nil
         (view as! StateMachineView).intermediateButtonAction = nil
         (view as! StateMachineView).expertButtonAction = nil

--- a/Example-iOS/Source/UIkit/iosPlayer.swift
+++ b/Example-iOS/Source/UIkit/iosPlayer.swift
@@ -18,7 +18,7 @@ class IOSPlayerView: UIView {
 class FileChoiceDelegate: NSObject, UIPickerViewDataSource, UIPickerViewDelegate {
     let choices = ["artboard_animations", "basketball", "clipping", "explorer", "f22", "flux_capacitor", "loopy", "mascot", "neostream", "off_road_car_blog", "progress", "pull", "rope", "skills", "trailblaze", "ui_swipe_left_to_delete", "vader", "wacky", "juice_v7", "truck_v7"]
     var chosen = "skills"
-    var viewController:IOSPlayerViewController?
+    weak var viewController:IOSPlayerViewController?
     //MARK: - Pickerview method
    func numberOfComponents(in pickerView: UIPickerView) -> Int {
     return 1
@@ -38,7 +38,7 @@ class FileChoiceDelegate: NSObject, UIPickerViewDataSource, UIPickerViewDelegate
 class ArtboardChoicesDelegate: NSObject, UIPickerViewDataSource, UIPickerViewDelegate {
     var choices = [""]
     var chosen:String?
-    var viewController:IOSPlayerViewController?
+    weak var viewController:IOSPlayerViewController?
     
    func numberOfComponents(in pickerView: UIPickerView) -> Int {
         return 1
@@ -118,20 +118,20 @@ class IOSPlayerViewController: UIViewController {
                 let play = UIButton(
                     type: .system,
                     primaryAction:
-                        UIAction(title: ">", handler: { _ in
+                        UIAction(title: ">", handler: { [unowned self] _ in
                             self.playerView?.riveView?.play(animationName: name)
                         }))
                 let pause = UIButton(
                     type: .system,
                     primaryAction:
-                        UIAction(title: "||", handler: { _ in
+                        UIAction(title: "||", handler: { [unowned self] _ in
                             self.playerView?.riveView?.pause(animationName: name)
                         }))
                 
                 let stop = UIButton(
                     type: .system,
                     primaryAction:
-                        UIAction(title: "[]", handler: { _ in
+                        UIAction(title: "[]", handler: { [unowned self] _ in
                             self.playerView?.riveView?.stop(animationName: name)
                         }))
                 
@@ -193,20 +193,20 @@ class IOSPlayerViewController: UIViewController {
                 let play = UIButton(
                     type: .system,
                     primaryAction:
-                        UIAction(title: ">", handler: { _ in
+                        UIAction(title: ">", handler: { [unowned self] _ in
                             self.playerView?.riveView?.play(animationName: name, isStateMachine: true)
                         }))
                 let pause = UIButton(
                     type: .system,
                     primaryAction:
-                        UIAction(title: "||", handler: { _ in
+                        UIAction(title: "||", handler: { [unowned self] _ in
                             self.playerView?.riveView?.pause(animationName: name, isStateMachine: true)
                         }))
                 
                 let stop = UIButton(
                     type: .system,
                     primaryAction:
-                        UIAction(title: "[]", handler: { _ in
+                        UIAction(title: "[]", handler: { [unowned self] _ in
                             self.playerView?.riveView?.stop(animationName: name, isStateMachine: true)
                         }))
                 
@@ -249,7 +249,7 @@ class IOSPlayerViewController: UIViewController {
                         let switchToggle = UISwitch(
                             frame: CGRect(),
                             primaryAction: UIAction(
-                                handler: { this in
+                                handler: { [unowned self] this in
                                     if ((this.sender as! UISwitch).isOn){
                                         self.playerView?.riveView.setBooleanState(name, inputName: inputName, value: true)
                                     }
@@ -265,7 +265,7 @@ class IOSPlayerViewController: UIViewController {
                         let fireButton = UIButton(
                             type: .system,
                             primaryAction:
-                                UIAction(title: "fire", handler: { _ in
+                                UIAction(title: "fire", handler: { [unowned self] _ in
                                     self.playerView?.riveView.fireState(name, inputName: inputName)
                                 }))
                         stackView.addArrangedSubview(fireButton)
@@ -279,7 +279,7 @@ class IOSPlayerViewController: UIViewController {
                         let downButton = UIButton(
                             type: .system,
                             primaryAction:
-                                UIAction(title: "-", handler: { _ in
+                                UIAction(title: "-", handler: { [unowned self] _ in
                                     let currentValue = (valueLabel.text! as NSString)
                                     let currentFloat = currentValue.floatValue - 1
                                     valueLabel.text = NSString(format: "%.2f", currentFloat) as String
@@ -289,7 +289,7 @@ class IOSPlayerViewController: UIViewController {
                         let upButton = UIButton(
                             type: .system,
                             primaryAction:
-                                UIAction(title: "+", handler: { _ in
+                                UIAction(title: "+", handler: { [unowned self] _ in
                                     let currentValue = (valueLabel.text! as NSString)
                                     let currentFloat = currentValue.floatValue + 1
                                     valueLabel.text = NSString(format: "%.2f", currentFloat) as String

--- a/Example-iOS/Source/UIkit/iosPlayer.swift
+++ b/Example-iOS/Source/UIkit/iosPlayer.swift
@@ -334,6 +334,5 @@ class IOSPlayerViewController: UIViewController {
     
     override public func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        (view as! IOSPlayerView).riveView.stop()
     }
 }

--- a/Source/Renderer/RiveArtboard.mm
+++ b/Source/Renderer/RiveArtboard.mm
@@ -41,7 +41,7 @@
 
 - (RiveLinearAnimation *)animationFromIndex:(NSInteger)index {
     if (index < 0 || index >= [self animationCount]) {
-        @throw [[RiveException alloc] initWithName:@"NoAnimationFound" reason:[NSString stringWithFormat: @"No Animation found at index %ld.", index] userInfo:nil];
+        @throw [[RiveException alloc] initWithName:@"NoAnimationFound" reason:[NSString stringWithFormat: @"No Animation found at index %ld.", (long)index] userInfo:nil];
     }
     return [[RiveLinearAnimation alloc] initWithAnimation: _artboard->animation(index)];
 }
@@ -82,7 +82,7 @@
 // Returns a state machine at the given index, or null if the index is invalid
 - (RiveStateMachine *)stateMachineFromIndex:(NSInteger)index {
     if (index < 0 || index >= [self stateMachineCount]) {
-        @throw [[RiveException alloc] initWithName:@"NoStateMachineFound" reason:[NSString stringWithFormat: @"No State Machine found at index %ld.", index] userInfo:nil];
+        @throw [[RiveException alloc] initWithName:@"NoStateMachineFound" reason:[NSString stringWithFormat: @"No State Machine found at index %ld.", (long)index] userInfo:nil];
     }
     return [[RiveStateMachine alloc] initWithStateMachine: _artboard->stateMachine(index)];
 }

--- a/Source/Renderer/RiveFile.mm
+++ b/Source/Renderer/RiveFile.mm
@@ -72,14 +72,14 @@
     NSData *fileData = [NSData dataWithContentsOfURL:fileUrl];
     UInt8 *bytePtr = (UInt8 *)[fileData bytes];
     
-    return [[RiveFile alloc] initWithBytes:bytePtr byteLength:fileData.length];
+    return [self initWithBytes:bytePtr byteLength:fileData.length];
 }
 
 /*
  * Creates a RiveFile from a binary resource, and assumes the resource extension is '.riv'
  */
 - (nullable instancetype)initWithResource:(NSString *)resourceName {
-    return [[RiveFile alloc] initWithResource:resourceName withExtension:@"riv"];
+    return [self initWithResource:resourceName withExtension:@"riv"];
 }
 
 /*

--- a/Source/Renderer/RiveFile.mm
+++ b/Source/Renderer/RiveFile.mm
@@ -156,7 +156,7 @@
 
 - (RiveArtboard *)artboardFromIndex:(NSInteger)index {
     if (index >= [self artboardCount]) {
-        @throw [[RiveException alloc] initWithName:@"NoArtboardFound" reason:[NSString stringWithFormat: @"No Artboard Found at index %ld.", index] userInfo:nil];
+        @throw [[RiveException alloc] initWithName:@"NoArtboardFound" reason:[NSString stringWithFormat: @"No Artboard Found at index %ld.", (long)index] userInfo:nil];
     }
     return [[RiveArtboard alloc]
             initWithArtboard: reinterpret_cast<rive::Artboard *>(riveFile->artboard(index))];

--- a/Source/Renderer/RiveStateMachine.mm
+++ b/Source/Renderer/RiveStateMachine.mm
@@ -65,7 +65,7 @@
 // Creates a new instance of this state machine
 - (RiveStateMachineInput *)inputFromIndex:(NSInteger)index {
     if (index >= [self inputCount]) {
-        @throw [[RiveException alloc] initWithName:@"NoStateMachineInputFound" reason:[NSString stringWithFormat: @"No Input found at index %ld.", index] userInfo:nil];
+        @throw [[RiveException alloc] initWithName:@"NoStateMachineInputFound" reason:[NSString stringWithFormat: @"No Input found at index %ld.", (long)index] userInfo:nil];
     }
     return [self _convertInput: stateMachine->input(index) ];
 }

--- a/Source/Renderer/RiveStateMachineInstance.mm
+++ b/Source/Renderer/RiveStateMachineInstance.mm
@@ -130,7 +130,7 @@
 // Creates a new instance of this state machine
 - (RiveSMIInput *)inputFromIndex:(NSInteger)index {
     if (index >= [self inputCount]) {
-        @throw [[RiveException alloc] initWithName:@"NoStateMachineInputFound" reason:[NSString stringWithFormat: @"No Input found at index %ld.", index] userInfo:nil];
+        @throw [[RiveException alloc] initWithName:@"NoStateMachineInputFound" reason:[NSString stringWithFormat: @"No Input found at index %ld.", (long)index] userInfo:nil];
     }
     return [self _convertInput: instance->input(index) ];
 }
@@ -184,7 +184,7 @@
 - (RiveLayerState *)stateChangedFromIndex:(NSInteger)index{
     const rive::LayerState *layerState = instance->stateChangedByIndex(index);
     if (layerState == nullptr) {
-        @throw [[RiveException alloc] initWithName:@"NoStateChangeFound" reason:[NSString stringWithFormat: @"No State Changed found at index %lu.", index] userInfo:nil];
+        @throw [[RiveException alloc] initWithName:@"NoStateChangeFound" reason:[NSString stringWithFormat: @"No State Changed found at index %ld.", (long)index] userInfo:nil];
     } else {
         return [self _convertLayerState: layerState];
     }

--- a/Source/Views/RiveView.swift
+++ b/Source/Views/RiveView.swift
@@ -413,12 +413,13 @@ extension RiveView {
     // Starts the animation timer
     private func runTimer() {
         if displayLink == nil {
-//            displayLinkProxy = CADisplayLinkProxy(
-//                handle: { [weak self] in
-//                    self?.tick()
-//                }, to: .main, forMode: .common)
-            displayLink = CADisplayLink(target: self, selector: #selector(tick))
-            displayLink?.add(to: .main, forMode: .common)
+            displayLinkProxy = CADisplayLinkProxy(
+                handle: { [weak self] in
+                    self?.tick()
+                }, to: .main, forMode: .common)
+//            TODO: delete after talking about it.
+//            displayLink = CADisplayLink(target: self, selector: #selector(tick))
+//            displayLink?.add(to: .main, forMode: .common)
         }
         if displayLinkProxy?.displayLink?.isPaused == true {
             lastTime = 0
@@ -443,16 +444,16 @@ extension RiveView {
     /// - if the artboard has come to a stop, stop.
     @objc func tick() {
         print("tick")
-//        guard let displayLink = displaylinkProxy?.displaylink else {
-//            // Something's gone wrong, clean up and bug out
-//            stopTimer()
-//            return
-//        }
-        guard let displayLink = displayLink else {
+        guard let displayLink = displayLinkProxy?.displayLink else {
             // Something's gone wrong, clean up and bug out
             stopTimer()
             return
         }
+//        guard let displayLink = displayLink else {
+//            // Something's gone wrong, clean up and bug out
+//            stopTimer()
+//            return
+//        }
         
         let timestamp = displayLink.timestamp
         // last time needs to be set on the first tick


### PR DESCRIPTION
sorting one memory leak in our runtimes, and a few cyclic dependencies in our examples.

those callbacks were keeping the view around... 

`[unowned self]` is important in those callback closures you see in the ios player example, without them the closure will keep the view alive. 

setting the callbacks to nil is important in the other files, as i have not figured out how to make the reference to the view weak in those cases.... 