### PR TITLE
chroe: add github token to build script

### DIFF
--- a/.github/workflows/build_frameworks.yml
+++ b/.github/workflows/build_frameworks.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Get Version
         run: npm run release -- --ci --release-version | tail -n 1 > RELEASE_VERSION
         working-directory: ./.github/scripts/release
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
looks like we missed out an env variable now that we changed the config to include github, just going to merge these until it works