### PR TITLE
Add support for non clipping artboards

### DIFF
--- a/RiveRuntime.xcodeproj/project.pbxproj
+++ b/RiveRuntime.xcodeproj/project.pbxproj
@@ -61,224 +61,249 @@
 		04F1C93126A84B8700CEE6BE /* blend_state_transition_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F1C92C26A84B8700CEE6BE /* blend_state_transition_base.cpp */; };
 		04F1C93226A84B8700CEE6BE /* blend_state_1d_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F1C92D26A84B8700CEE6BE /* blend_state_1d_base.cpp */; };
 		04F1C93326A84B8700CEE6BE /* blend_state_direct_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F1C92E26A84B8700CEE6BE /* blend_state_direct_base.cpp */; };
-		04F461B426C4030D007CEEAB /* core_registry.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460CC26C4030C007CEEAB /* core_registry.hpp */; };
-		04F461B526C4030D007CEEAB /* node_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460CD26C4030C007CEEAB /* node_base.hpp */; };
-		04F461B626C4030D007CEEAB /* transform_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460CE26C4030C007CEEAB /* transform_component_base.hpp */; };
-		04F461B726C4030D007CEEAB /* constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D026C4030C007CEEAB /* constraint_base.hpp */; };
-		04F461B826C4030D007CEEAB /* targeted_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D126C4030C007CEEAB /* targeted_constraint_base.hpp */; };
-		04F461B926C4030D007CEEAB /* ik_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D226C4030C007CEEAB /* ik_constraint_base.hpp */; };
-		04F461BA26C4030D007CEEAB /* transform_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D326C4030C007CEEAB /* transform_constraint_base.hpp */; };
-		04F461BB26C4030D007CEEAB /* distance_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D426C4030C007CEEAB /* distance_constraint_base.hpp */; };
-		04F461BC26C4030D007CEEAB /* artboard_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D526C4030C007CEEAB /* artboard_base.hpp */; };
-		04F461BD26C4030D007CEEAB /* draw_rules_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D626C4030C007CEEAB /* draw_rules_base.hpp */; };
-		04F461BE26C4030D007CEEAB /* blend_animation_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D826C4030C007CEEAB /* blend_animation_base.hpp */; };
-		04F461BF26C4030D007CEEAB /* keyframe_color_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D926C4030C007CEEAB /* keyframe_color_base.hpp */; };
-		04F461C026C4030D007CEEAB /* keyed_property_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460DA26C4030C007CEEAB /* keyed_property_base.hpp */; };
-		04F461C126C4030D007CEEAB /* keyframe_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460DB26C4030C007CEEAB /* keyframe_base.hpp */; };
-		04F461C226C4030D007CEEAB /* animation_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460DC26C4030C007CEEAB /* animation_state_base.hpp */; };
-		04F461C326C4030D007CEEAB /* animation_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460DD26C4030C007CEEAB /* animation_base.hpp */; };
-		04F461C426C4030D007CEEAB /* blend_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460DE26C4030C007CEEAB /* blend_state_base.hpp */; };
-		04F461C526C4030D007CEEAB /* transition_number_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460DF26C4030C007CEEAB /* transition_number_condition_base.hpp */; };
-		04F461C626C4030D007CEEAB /* cubic_interpolator_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E026C4030C007CEEAB /* cubic_interpolator_base.hpp */; };
-		04F461C726C4030D007CEEAB /* linear_animation_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E126C4030C007CEEAB /* linear_animation_base.hpp */; };
-		04F461C826C4030D007CEEAB /* entry_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E226C4030C007CEEAB /* entry_state_base.hpp */; };
-		04F461C926C4030D007CEEAB /* layer_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E326C4030C007CEEAB /* layer_state_base.hpp */; };
-		04F461CA26C4030D007CEEAB /* state_machine_layer_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E426C4030C007CEEAB /* state_machine_layer_component_base.hpp */; };
-		04F461CB26C4030D007CEEAB /* blend_state_direct_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E526C4030C007CEEAB /* blend_state_direct_base.hpp */; };
-		04F461CC26C4030D007CEEAB /* state_machine_layer_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E626C4030C007CEEAB /* state_machine_layer_base.hpp */; };
-		04F461CD26C4030D007CEEAB /* keyframe_id_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E726C4030C007CEEAB /* keyframe_id_base.hpp */; };
-		04F461CE26C4030D007CEEAB /* blend_animation_1d_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E826C4030C007CEEAB /* blend_animation_1d_base.hpp */; };
-		04F461CF26C4030D007CEEAB /* keyed_object_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E926C4030C007CEEAB /* keyed_object_base.hpp */; };
-		04F461D026C4030D007CEEAB /* transition_value_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460EA26C4030C007CEEAB /* transition_value_condition_base.hpp */; };
-		04F461D126C4030D007CEEAB /* state_machine_number_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460EB26C4030C007CEEAB /* state_machine_number_base.hpp */; };
-		04F461D226C4030D007CEEAB /* state_transition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460EC26C4030C007CEEAB /* state_transition_base.hpp */; };
-		04F461D326C4030D007CEEAB /* keyframe_double_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460ED26C4030C007CEEAB /* keyframe_double_base.hpp */; };
-		04F461D426C4030D007CEEAB /* state_machine_bool_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460EE26C4030C007CEEAB /* state_machine_bool_base.hpp */; };
-		04F461D526C4030D007CEEAB /* blend_state_transition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460EF26C4030C007CEEAB /* blend_state_transition_base.hpp */; };
-		04F461D626C4030D007CEEAB /* blend_animation_direct_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F026C4030C007CEEAB /* blend_animation_direct_base.hpp */; };
-		04F461D726C4030D007CEEAB /* transition_bool_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F126C4030C007CEEAB /* transition_bool_condition_base.hpp */; };
-		04F461D826C4030D007CEEAB /* transition_trigger_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F226C4030C007CEEAB /* transition_trigger_condition_base.hpp */; };
-		04F461D926C4030D007CEEAB /* state_machine_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F326C4030C007CEEAB /* state_machine_component_base.hpp */; };
-		04F461DA26C4030D007CEEAB /* any_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F426C4030C007CEEAB /* any_state_base.hpp */; };
-		04F461DB26C4030D007CEEAB /* transition_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F526C4030C007CEEAB /* transition_condition_base.hpp */; };
-		04F461DC26C4030D007CEEAB /* state_machine_input_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F626C4030C007CEEAB /* state_machine_input_base.hpp */; };
-		04F461DD26C4030D007CEEAB /* blend_state_1d_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F726C4030D007CEEAB /* blend_state_1d_base.hpp */; };
-		04F461DE26C4030D007CEEAB /* state_machine_trigger_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F826C4030D007CEEAB /* state_machine_trigger_base.hpp */; };
-		04F461DF26C4030D007CEEAB /* state_machine_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F926C4030D007CEEAB /* state_machine_base.hpp */; };
-		04F461E026C4030D007CEEAB /* exit_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460FA26C4030D007CEEAB /* exit_state_base.hpp */; };
-		04F461E126C4030D007CEEAB /* linear_gradient_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460FD26C4030D007CEEAB /* linear_gradient_base.hpp */; };
-		04F461E226C4030D007CEEAB /* stroke_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460FE26C4030D007CEEAB /* stroke_base.hpp */; };
-		04F461E326C4030D007CEEAB /* fill_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460FF26C4030D007CEEAB /* fill_base.hpp */; };
-		04F461E426C4030D007CEEAB /* shape_paint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610026C4030D007CEEAB /* shape_paint_base.hpp */; };
-		04F461E526C4030D007CEEAB /* solid_color_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610126C4030D007CEEAB /* solid_color_base.hpp */; };
-		04F461E626C4030D007CEEAB /* trim_path_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610226C4030D007CEEAB /* trim_path_base.hpp */; };
-		04F461E726C4030D007CEEAB /* radial_gradient_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610326C4030D007CEEAB /* radial_gradient_base.hpp */; };
-		04F461E826C4030D007CEEAB /* gradient_stop_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610426C4030D007CEEAB /* gradient_stop_base.hpp */; };
-		04F461E926C4030D007CEEAB /* parametric_path_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610526C4030D007CEEAB /* parametric_path_base.hpp */; };
-		04F461EA26C4030D007CEEAB /* cubic_asymmetric_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610626C4030D007CEEAB /* cubic_asymmetric_vertex_base.hpp */; };
-		04F461EB26C4030D007CEEAB /* cubic_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610726C4030D007CEEAB /* cubic_vertex_base.hpp */; };
-		04F461EC26C4030D007CEEAB /* ellipse_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610826C4030D007CEEAB /* ellipse_base.hpp */; };
-		04F461ED26C4030D007CEEAB /* points_path_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610926C4030D007CEEAB /* points_path_base.hpp */; };
-		04F461EE26C4030D007CEEAB /* triangle_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610A26C4030D007CEEAB /* triangle_base.hpp */; };
-		04F461EF26C4030D007CEEAB /* shape_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610B26C4030D007CEEAB /* shape_base.hpp */; };
-		04F461F026C4030D007CEEAB /* rectangle_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610C26C4030D007CEEAB /* rectangle_base.hpp */; };
-		04F461F126C4030D007CEEAB /* cubic_mirrored_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610D26C4030D007CEEAB /* cubic_mirrored_vertex_base.hpp */; };
-		04F461F226C4030D007CEEAB /* star_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610E26C4030D007CEEAB /* star_base.hpp */; };
-		04F461F326C4030D007CEEAB /* straight_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610F26C4030D007CEEAB /* straight_vertex_base.hpp */; };
-		04F461F426C4030D007CEEAB /* path_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611026C4030D007CEEAB /* path_base.hpp */; };
-		04F461F526C4030D007CEEAB /* polygon_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611126C4030D007CEEAB /* polygon_base.hpp */; };
-		04F461F626C4030D007CEEAB /* cubic_detached_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611226C4030D007CEEAB /* cubic_detached_vertex_base.hpp */; };
-		04F461F726C4030D007CEEAB /* clipping_shape_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611326C4030D007CEEAB /* clipping_shape_base.hpp */; };
-		04F461F826C4030D007CEEAB /* path_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611426C4030D007CEEAB /* path_vertex_base.hpp */; };
-		04F461F926C4030D007CEEAB /* container_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611526C4030D007CEEAB /* container_component_base.hpp */; };
-		04F461FA26C4030D007CEEAB /* component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611626C4030D007CEEAB /* component_base.hpp */; };
-		04F461FB26C4030D007CEEAB /* weight_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611826C4030D007CEEAB /* weight_base.hpp */; };
-		04F461FC26C4030D007CEEAB /* root_bone_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611926C4030D007CEEAB /* root_bone_base.hpp */; };
-		04F461FD26C4030D007CEEAB /* cubic_weight_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611A26C4030D007CEEAB /* cubic_weight_base.hpp */; };
-		04F461FE26C4030D007CEEAB /* bone_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611B26C4030D007CEEAB /* bone_base.hpp */; };
-		04F461FF26C4030D007CEEAB /* skin_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611C26C4030D007CEEAB /* skin_base.hpp */; };
-		04F4620026C4030D007CEEAB /* tendon_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611D26C4030D007CEEAB /* tendon_base.hpp */; };
-		04F4620126C4030D007CEEAB /* skeletal_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611E26C4030D007CEEAB /* skeletal_component_base.hpp */; };
-		04F4620226C4030D007CEEAB /* draw_target_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611F26C4030D007CEEAB /* draw_target_base.hpp */; };
-		04F4620326C4030D007CEEAB /* backboard_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612026C4030D007CEEAB /* backboard_base.hpp */; };
-		04F4620426C4030D007CEEAB /* drawable_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612126C4030D007CEEAB /* drawable_base.hpp */; };
-		04F4620526C4030D007CEEAB /* backboard.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612226C4030D007CEEAB /* backboard.hpp */; };
-		04F4620626C4030D007CEEAB /* reader.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612426C4030D007CEEAB /* reader.h */; };
-		04F4620726C4030D007CEEAB /* core_color_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612626C4030D007CEEAB /* core_color_type.hpp */; };
-		04F4620826C4030D007CEEAB /* core_uint_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612726C4030D007CEEAB /* core_uint_type.hpp */; };
-		04F4620926C4030D007CEEAB /* core_double_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612826C4030D007CEEAB /* core_double_type.hpp */; };
-		04F4620A26C4030D007CEEAB /* core_string_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612926C4030D007CEEAB /* core_string_type.hpp */; };
-		04F4620B26C4030D007CEEAB /* core_bool_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612A26C4030D007CEEAB /* core_bool_type.hpp */; };
-		04F4620C26C4030D007CEEAB /* binary_reader.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612B26C4030D007CEEAB /* binary_reader.hpp */; };
-		04F4620D26C4030D007CEEAB /* status_code.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612C26C4030D007CEEAB /* status_code.hpp */; };
-		04F4620E26C4030D007CEEAB /* targeted_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612E26C4030D007CEEAB /* targeted_constraint.hpp */; };
-		04F4620F26C4030D007CEEAB /* constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612F26C4030D007CEEAB /* constraint.hpp */; };
-		04F4621026C4030D007CEEAB /* ik_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613026C4030D007CEEAB /* ik_constraint.hpp */; };
-		04F4621126C4030D007CEEAB /* transform_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613126C4030D007CEEAB /* transform_constraint.hpp */; };
-		04F4621226C4030D007CEEAB /* distance_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613226C4030D007CEEAB /* distance_constraint.hpp */; };
-		04F4621326C4030D007CEEAB /* component_dirt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613326C4030D007CEEAB /* component_dirt.hpp */; };
-		04F4621426C4030D007CEEAB /* renderer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613426C4030D007CEEAB /* renderer.hpp */; };
-		04F4621526C4030D007CEEAB /* draw_target_placement.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613526C4030D007CEEAB /* draw_target_placement.hpp */; };
-		04F4621626C4030D007CEEAB /* state_transition_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613726C4030D007CEEAB /* state_transition_importer.hpp */; };
-		04F4621726C4030D007CEEAB /* state_machine_layer_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613826C4030D007CEEAB /* state_machine_layer_importer.hpp */; };
-		04F4621826C4030D007CEEAB /* keyed_property_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613926C4030D007CEEAB /* keyed_property_importer.hpp */; };
-		04F4621926C4030D007CEEAB /* keyed_object_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613A26C4030D007CEEAB /* keyed_object_importer.hpp */; };
-		04F4621A26C4030D007CEEAB /* linear_animation_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613B26C4030D007CEEAB /* linear_animation_importer.hpp */; };
-		04F4621B26C4030D007CEEAB /* import_stack.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613C26C4030D007CEEAB /* import_stack.hpp */; };
-		04F4621C26C4030D007CEEAB /* layer_state_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613D26C4030D007CEEAB /* layer_state_importer.hpp */; };
-		04F4621D26C4030D007CEEAB /* artboard_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613E26C4030D007CEEAB /* artboard_importer.hpp */; };
-		04F4621E26C4030D007CEEAB /* state_machine_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613F26C4030D007CEEAB /* state_machine_importer.hpp */; };
-		04F4621F26C4030D007CEEAB /* draw_target.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614026C4030D007CEEAB /* draw_target.hpp */; };
-		04F4622026C4030D007CEEAB /* runtime_header.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614126C4030D007CEEAB /* runtime_header.hpp */; };
-		04F4622126C4030D007CEEAB /* file.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614226C4030D007CEEAB /* file.hpp */; };
-		04F4622226C4030D007CEEAB /* container_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614326C4030D007CEEAB /* container_component.hpp */; };
-		04F4622326C4030D007CEEAB /* transition_bool_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614526C4030D007CEEAB /* transition_bool_condition.hpp */; };
-		04F4622426C4030D007CEEAB /* cubic_interpolator.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614626C4030D007CEEAB /* cubic_interpolator.hpp */; };
-		04F4622526C4030D007CEEAB /* keyed_property.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614726C4030D007CEEAB /* keyed_property.hpp */; };
-		04F4622626C4030D007CEEAB /* state_machine_input.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614826C4030D007CEEAB /* state_machine_input.hpp */; };
-		04F4622726C4030D007CEEAB /* layer_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614926C4030D007CEEAB /* layer_state.hpp */; };
-		04F4622826C4030D007CEEAB /* state_transition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614A26C4030D007CEEAB /* state_transition.hpp */; };
-		04F4622926C4030D007CEEAB /* system_state_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614B26C4030D007CEEAB /* system_state_instance.hpp */; };
-		04F4622A26C4030D007CEEAB /* state_machine_trigger.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614C26C4030D007CEEAB /* state_machine_trigger.hpp */; };
-		04F4622B26C4030D007CEEAB /* keyframe_id.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614D26C4030D007CEEAB /* keyframe_id.hpp */; };
-		04F4622C26C4030D007CEEAB /* blend_state_transition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614E26C4030D007CEEAB /* blend_state_transition.hpp */; };
-		04F4622D26C4030D007CEEAB /* transition_number_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614F26C4030D007CEEAB /* transition_number_condition.hpp */; };
-		04F4622E26C4030D007CEEAB /* state_machine_number.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615026C4030D007CEEAB /* state_machine_number.hpp */; };
-		04F4622F26C4030D007CEEAB /* animation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615126C4030D007CEEAB /* animation.hpp */; };
-		04F4623026C4030D007CEEAB /* keyframe.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615226C4030D007CEEAB /* keyframe.hpp */; };
-		04F4623126C4030D007CEEAB /* blend_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615326C4030D007CEEAB /* blend_state.hpp */; };
-		04F4623226C4030D007CEEAB /* state_machine_layer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615426C4030D007CEEAB /* state_machine_layer.hpp */; };
-		04F4623326C4030D007CEEAB /* blend_animation_1d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615526C4030D007CEEAB /* blend_animation_1d.hpp */; };
-		04F4623426C4030D007CEEAB /* state_machine_layer_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615626C4030D007CEEAB /* state_machine_layer_component.hpp */; };
-		04F4623526C4030D007CEEAB /* blend_state_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615726C4030D007CEEAB /* blend_state_instance.hpp */; };
-		04F4623626C4030D007CEEAB /* state_machine_bool.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615826C4030D007CEEAB /* state_machine_bool.hpp */; };
-		04F4623726C4030D007CEEAB /* blend_state_1d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615926C4030D007CEEAB /* blend_state_1d.hpp */; };
-		04F4623826C4030D007CEEAB /* state_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615A26C4030D007CEEAB /* state_instance.hpp */; };
-		04F4623926C4030D007CEEAB /* keyed_object.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615B26C4030D007CEEAB /* keyed_object.hpp */; };
-		04F4623A26C4030D007CEEAB /* state_machine_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615C26C4030D007CEEAB /* state_machine_component.hpp */; };
-		04F4623B26C4030D007CEEAB /* state_machine.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615D26C4030D007CEEAB /* state_machine.hpp */; };
-		04F4623C26C4030D007CEEAB /* blend_state_1d_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615E26C4030D007CEEAB /* blend_state_1d_instance.hpp */; };
-		04F4623D26C4030D007CEEAB /* state_machine_input_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615F26C4030D007CEEAB /* state_machine_input_instance.hpp */; };
-		04F4623E26C4030D007CEEAB /* transition_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616026C4030D007CEEAB /* transition_condition.hpp */; };
-		04F4623F26C4030D007CEEAB /* transition_value_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616126C4030D007CEEAB /* transition_value_condition.hpp */; };
-		04F4624026C4030D007CEEAB /* animation_state_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616226C4030D007CEEAB /* animation_state_instance.hpp */; };
-		04F4624126C4030D007CEEAB /* linear_animation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616326C4030D007CEEAB /* linear_animation.hpp */; };
-		04F4624226C4030D007CEEAB /* linear_animation_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616426C4030D007CEEAB /* linear_animation_instance.hpp */; };
-		04F4624326C4030D007CEEAB /* transition_condition_op.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616526C4030D007CEEAB /* transition_condition_op.hpp */; };
-		04F4624426C4030D007CEEAB /* blend_state_direct_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616626C4030D007CEEAB /* blend_state_direct_instance.hpp */; };
-		04F4624526C4030D007CEEAB /* keyframe_double.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616726C4030D007CEEAB /* keyframe_double.hpp */; };
-		04F4624626C4030D007CEEAB /* blend_animation_direct.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616826C4030D007CEEAB /* blend_animation_direct.hpp */; };
-		04F4624726C4030D007CEEAB /* loop.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616926C4030D007CEEAB /* loop.hpp */; };
-		04F4624826C4030D007CEEAB /* keyframe_color.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616A26C4030D007CEEAB /* keyframe_color.hpp */; };
-		04F4624926C4030D007CEEAB /* entry_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616B26C4030D007CEEAB /* entry_state.hpp */; };
-		04F4624A26C4030D007CEEAB /* blend_animation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616C26C4030D007CEEAB /* blend_animation.hpp */; };
-		04F4624B26C4030D007CEEAB /* state_machine_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616D26C4030D007CEEAB /* state_machine_instance.hpp */; };
-		04F4624C26C4030D007CEEAB /* state_transition_flags.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616E26C4030D007CEEAB /* state_transition_flags.hpp */; };
-		04F4624D26C4030D007CEEAB /* exit_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616F26C4030D007CEEAB /* exit_state.hpp */; };
-		04F4624E26C4030D007CEEAB /* any_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617026C4030D007CEEAB /* any_state.hpp */; };
-		04F4624F26C4030D007CEEAB /* animation_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617126C4030D007CEEAB /* animation_state.hpp */; };
-		04F4625026C4030D007CEEAB /* blend_state_direct.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617226C4030D007CEEAB /* blend_state_direct.hpp */; };
-		04F4625126C4030D007CEEAB /* transition_trigger_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617326C4030D007CEEAB /* transition_trigger_condition.hpp */; };
-		04F4625226C4030D007CEEAB /* transform_space.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617426C4030D007CEEAB /* transform_space.hpp */; };
-		04F4625326C4030D007CEEAB /* straight_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617626C4030D007CEEAB /* straight_vertex.hpp */; };
-		04F4625426C4030D007CEEAB /* stroke_cap.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617826C4030D007CEEAB /* stroke_cap.hpp */; };
-		04F4625526C4030D007CEEAB /* gradient_stop.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617926C4030D007CEEAB /* gradient_stop.hpp */; };
-		04F4625626C4030D007CEEAB /* stroke.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617A26C4030D007CEEAB /* stroke.hpp */; };
-		04F4625726C4030D007CEEAB /* shape_paint_mutator.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617B26C4030D007CEEAB /* shape_paint_mutator.hpp */; };
-		04F4625826C4030D007CEEAB /* blend_mode.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617C26C4030D007CEEAB /* blend_mode.hpp */; };
-		04F4625926C4030D007CEEAB /* shape_paint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617D26C4030D007CEEAB /* shape_paint.hpp */; };
-		04F4625A26C4030D007CEEAB /* stroke_join.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617E26C4030D007CEEAB /* stroke_join.hpp */; };
-		04F4625B26C4030D007CEEAB /* fill.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617F26C4030D007CEEAB /* fill.hpp */; };
-		04F4625C26C4030D007CEEAB /* radial_gradient.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618026C4030D007CEEAB /* radial_gradient.hpp */; };
-		04F4625D26C4030D007CEEAB /* trim_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618126C4030D007CEEAB /* trim_path.hpp */; };
-		04F4625E26C4030D007CEEAB /* color.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618226C4030D007CEEAB /* color.hpp */; };
-		04F4625F26C4030D007CEEAB /* solid_color.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618326C4030D007CEEAB /* solid_color.hpp */; };
-		04F4626026C4030D007CEEAB /* linear_gradient.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618426C4030D007CEEAB /* linear_gradient.hpp */; };
-		04F4626126C4030D007CEEAB /* stroke_effect.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618526C4030D007CEEAB /* stroke_effect.hpp */; };
-		04F4626226C4030D007CEEAB /* path_composer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618626C4030D007CEEAB /* path_composer.hpp */; };
-		04F4626326C4030D007CEEAB /* shape_paint_container.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618726C4030D007CEEAB /* shape_paint_container.hpp */; };
-		04F4626426C4030D007CEEAB /* cubic_mirrored_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618826C4030D007CEEAB /* cubic_mirrored_vertex.hpp */; };
-		04F4626526C4030D007CEEAB /* path_space.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618926C4030D007CEEAB /* path_space.hpp */; };
-		04F4626626C4030D007CEEAB /* ellipse.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618A26C4030D007CEEAB /* ellipse.hpp */; };
-		04F4626726C4030D007CEEAB /* clipping_shape.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618B26C4030D007CEEAB /* clipping_shape.hpp */; };
-		04F4626826C4030D007CEEAB /* metrics_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618C26C4030D007CEEAB /* metrics_path.hpp */; };
-		04F4626926C4030D007CEEAB /* cubic_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618D26C4030D007CEEAB /* cubic_vertex.hpp */; };
-		04F4626A26C4030D007CEEAB /* shape.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618E26C4030D007CEEAB /* shape.hpp */; };
-		04F4626B26C4030D007CEEAB /* triangle.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618F26C4030D007CEEAB /* triangle.hpp */; };
-		04F4626C26C4030D007CEEAB /* path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619026C4030D007CEEAB /* path.hpp */; };
-		04F4626D26C4030D007CEEAB /* polygon.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619126C4030D007CEEAB /* polygon.hpp */; };
-		04F4626E26C4030D007CEEAB /* path_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619226C4030D007CEEAB /* path_vertex.hpp */; };
-		04F4626F26C4030D007CEEAB /* parametric_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619326C4030D007CEEAB /* parametric_path.hpp */; };
-		04F4627026C4030D007CEEAB /* rectangle.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619426C4030D007CEEAB /* rectangle.hpp */; };
-		04F4627126C4030D007CEEAB /* points_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619526C4030D007CEEAB /* points_path.hpp */; };
-		04F4627226C4030D007CEEAB /* star.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619626C4030D007CEEAB /* star.hpp */; };
-		04F4627326C4030D007CEEAB /* cubic_asymmetric_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619726C4030D007CEEAB /* cubic_asymmetric_vertex.hpp */; };
-		04F4627426C4030D007CEEAB /* cubic_detached_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619826C4030D007CEEAB /* cubic_detached_vertex.hpp */; };
-		04F4627526C4030D007CEEAB /* vec2d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619A26C4030D007CEEAB /* vec2d.hpp */; };
-		04F4627626C4030D007CEEAB /* mat2d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619B26C4030D007CEEAB /* mat2d.hpp */; };
-		04F4627726C4030D007CEEAB /* aabb.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619C26C4030D007CEEAB /* aabb.hpp */; };
-		04F4627826C4030D007CEEAB /* color.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619D26C4030D007CEEAB /* color.hpp */; };
-		04F4627926C4030D007CEEAB /* transform_components.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619E26C4030D007CEEAB /* transform_components.hpp */; };
-		04F4627A26C4030D007CEEAB /* circle_constant.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619F26C4030D007CEEAB /* circle_constant.hpp */; };
-		04F4627B26C4030D007CEEAB /* command_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A026C4030D007CEEAB /* command_path.hpp */; };
-		04F4627C26C4030D007CEEAB /* component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A126C4030D007CEEAB /* component.hpp */; };
-		04F4627D26C4030D007CEEAB /* node.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A226C4030D007CEEAB /* node.hpp */; };
-		04F4627E26C4030D007CEEAB /* layout.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A326C4030D007CEEAB /* layout.hpp */; };
-		04F4627F26C4030D007CEEAB /* drawable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A426C4030D007CEEAB /* drawable.hpp */; };
-		04F4628026C4030D007CEEAB /* artboard.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A526C4030D007CEEAB /* artboard.hpp */; };
-		04F4628126C4030D007CEEAB /* dependency_sorter.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A626C4030D007CEEAB /* dependency_sorter.hpp */; };
-		04F4628226C4030D007CEEAB /* core_context.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A726C4030D007CEEAB /* core_context.hpp */; };
-		04F4628326C4030D007CEEAB /* tendon.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A926C4030D007CEEAB /* tendon.hpp */; };
-		04F4628426C4030D007CEEAB /* skeletal_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461AA26C4030D007CEEAB /* skeletal_component.hpp */; };
-		04F4628526C4030D007CEEAB /* weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461AB26C4030D007CEEAB /* weight.hpp */; };
-		04F4628626C4030D007CEEAB /* skin.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461AC26C4030D007CEEAB /* skin.hpp */; };
-		04F4628726C4030D007CEEAB /* root_bone.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461AD26C4030D007CEEAB /* root_bone.hpp */; };
-		04F4628826C4030D007CEEAB /* bone.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461AE26C4030D007CEEAB /* bone.hpp */; };
-		04F4628926C4030D007CEEAB /* skinnable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461AF26C4030D007CEEAB /* skinnable.hpp */; };
-		04F4628A26C4030D007CEEAB /* cubic_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461B026C4030D007CEEAB /* cubic_weight.hpp */; };
-		04F4628B26C4030D007CEEAB /* draw_rules.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461B126C4030D007CEEAB /* draw_rules.hpp */; };
-		04F4628C26C4030D007CEEAB /* core.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461B226C4030D007CEEAB /* core.hpp */; };
-		04F4628D26C4030D007CEEAB /* transform_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461B326C4030D007CEEAB /* transform_component.hpp */; };
+		04F4646926C510E0007CEEAB /* core_registry.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4637126C510E0007CEEAB /* core_registry.hpp */; };
+		04F4646A26C510E0007CEEAB /* node_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4637226C510E0007CEEAB /* node_base.hpp */; };
+		04F4646B26C510E0007CEEAB /* transform_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4637326C510E0007CEEAB /* transform_component_base.hpp */; };
+		04F4646C26C510E0007CEEAB /* rotation_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4637526C510E0007CEEAB /* rotation_constraint_base.hpp */; };
+		04F4646D26C510E0007CEEAB /* constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4637626C510E0007CEEAB /* constraint_base.hpp */; };
+		04F4646E26C510E0007CEEAB /* targeted_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4637726C510E0007CEEAB /* targeted_constraint_base.hpp */; };
+		04F4646F26C510E0007CEEAB /* translation_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4637826C510E0007CEEAB /* translation_constraint_base.hpp */; };
+		04F4647026C510E0007CEEAB /* scale_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4637926C510E0007CEEAB /* scale_constraint_base.hpp */; };
+		04F4647126C510E1007CEEAB /* ik_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4637A26C510E0007CEEAB /* ik_constraint_base.hpp */; };
+		04F4647226C510E1007CEEAB /* transform_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4637B26C510E0007CEEAB /* transform_constraint_base.hpp */; };
+		04F4647326C510E1007CEEAB /* transform_component_constraint_y_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4637C26C510E0007CEEAB /* transform_component_constraint_y_base.hpp */; };
+		04F4647426C510E1007CEEAB /* transform_space_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4637D26C510E0007CEEAB /* transform_space_constraint_base.hpp */; };
+		04F4647526C510E1007CEEAB /* distance_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4637E26C510E0007CEEAB /* distance_constraint_base.hpp */; };
+		04F4647626C510E1007CEEAB /* transform_component_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4637F26C510E0007CEEAB /* transform_component_constraint_base.hpp */; };
+		04F4647726C510E1007CEEAB /* artboard_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4638026C510E0007CEEAB /* artboard_base.hpp */; };
+		04F4647826C510E1007CEEAB /* draw_rules_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4638126C510E0007CEEAB /* draw_rules_base.hpp */; };
+		04F4647926C510E1007CEEAB /* world_transform_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4638226C510E0007CEEAB /* world_transform_component_base.hpp */; };
+		04F4647A26C510E1007CEEAB /* blend_animation_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4638426C510E0007CEEAB /* blend_animation_base.hpp */; };
+		04F4647B26C510E1007CEEAB /* keyframe_bool_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4638526C510E0007CEEAB /* keyframe_bool_base.hpp */; };
+		04F4647C26C510E1007CEEAB /* keyframe_color_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4638626C510E0007CEEAB /* keyframe_color_base.hpp */; };
+		04F4647D26C510E1007CEEAB /* keyed_property_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4638726C510E0007CEEAB /* keyed_property_base.hpp */; };
+		04F4647E26C510E1007CEEAB /* keyframe_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4638826C510E0007CEEAB /* keyframe_base.hpp */; };
+		04F4647F26C510E1007CEEAB /* animation_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4638926C510E0007CEEAB /* animation_state_base.hpp */; };
+		04F4648026C510E1007CEEAB /* animation_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4638A26C510E0007CEEAB /* animation_base.hpp */; };
+		04F4648126C510E1007CEEAB /* blend_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4638B26C510E0007CEEAB /* blend_state_base.hpp */; };
+		04F4648226C510E1007CEEAB /* transition_number_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4638C26C510E0007CEEAB /* transition_number_condition_base.hpp */; };
+		04F4648326C510E1007CEEAB /* cubic_interpolator_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4638D26C510E0007CEEAB /* cubic_interpolator_base.hpp */; };
+		04F4648426C510E1007CEEAB /* linear_animation_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4638E26C510E0007CEEAB /* linear_animation_base.hpp */; };
+		04F4648526C510E1007CEEAB /* entry_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4638F26C510E0007CEEAB /* entry_state_base.hpp */; };
+		04F4648626C510E1007CEEAB /* layer_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4639026C510E0007CEEAB /* layer_state_base.hpp */; };
+		04F4648726C510E1007CEEAB /* state_machine_layer_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4639126C510E0007CEEAB /* state_machine_layer_component_base.hpp */; };
+		04F4648826C510E1007CEEAB /* blend_state_direct_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4639226C510E0007CEEAB /* blend_state_direct_base.hpp */; };
+		04F4648926C510E1007CEEAB /* state_machine_layer_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4639326C510E0007CEEAB /* state_machine_layer_base.hpp */; };
+		04F4648A26C510E1007CEEAB /* keyframe_id_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4639426C510E0007CEEAB /* keyframe_id_base.hpp */; };
+		04F4648B26C510E1007CEEAB /* blend_animation_1d_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4639526C510E0007CEEAB /* blend_animation_1d_base.hpp */; };
+		04F4648C26C510E1007CEEAB /* keyed_object_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4639626C510E0007CEEAB /* keyed_object_base.hpp */; };
+		04F4648D26C510E1007CEEAB /* transition_value_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4639726C510E0007CEEAB /* transition_value_condition_base.hpp */; };
+		04F4648E26C510E1007CEEAB /* state_machine_number_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4639826C510E0007CEEAB /* state_machine_number_base.hpp */; };
+		04F4648F26C510E1007CEEAB /* state_transition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4639926C510E0007CEEAB /* state_transition_base.hpp */; };
+		04F4649026C510E1007CEEAB /* keyframe_double_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4639A26C510E0007CEEAB /* keyframe_double_base.hpp */; };
+		04F4649126C510E1007CEEAB /* state_machine_bool_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4639B26C510E0007CEEAB /* state_machine_bool_base.hpp */; };
+		04F4649226C510E1007CEEAB /* blend_state_transition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4639C26C510E0007CEEAB /* blend_state_transition_base.hpp */; };
+		04F4649326C510E1007CEEAB /* blend_animation_direct_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4639D26C510E0007CEEAB /* blend_animation_direct_base.hpp */; };
+		04F4649426C510E1007CEEAB /* transition_bool_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4639E26C510E0007CEEAB /* transition_bool_condition_base.hpp */; };
+		04F4649526C510E1007CEEAB /* transition_trigger_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4639F26C510E0007CEEAB /* transition_trigger_condition_base.hpp */; };
+		04F4649626C510E1007CEEAB /* state_machine_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463A026C510E0007CEEAB /* state_machine_component_base.hpp */; };
+		04F4649726C510E1007CEEAB /* any_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463A126C510E0007CEEAB /* any_state_base.hpp */; };
+		04F4649826C510E1007CEEAB /* transition_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463A226C510E0007CEEAB /* transition_condition_base.hpp */; };
+		04F4649926C510E1007CEEAB /* state_machine_input_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463A326C510E0007CEEAB /* state_machine_input_base.hpp */; };
+		04F4649A26C510E1007CEEAB /* blend_state_1d_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463A426C510E0007CEEAB /* blend_state_1d_base.hpp */; };
+		04F4649B26C510E1007CEEAB /* state_machine_trigger_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463A526C510E0007CEEAB /* state_machine_trigger_base.hpp */; };
+		04F4649C26C510E1007CEEAB /* state_machine_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463A626C510E0007CEEAB /* state_machine_base.hpp */; };
+		04F4649D26C510E1007CEEAB /* exit_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463A726C510E0007CEEAB /* exit_state_base.hpp */; };
+		04F4649E26C510E1007CEEAB /* linear_gradient_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463AA26C510E0007CEEAB /* linear_gradient_base.hpp */; };
+		04F4649F26C510E1007CEEAB /* stroke_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463AB26C510E0007CEEAB /* stroke_base.hpp */; };
+		04F464A026C510E1007CEEAB /* fill_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463AC26C510E0007CEEAB /* fill_base.hpp */; };
+		04F464A126C510E1007CEEAB /* shape_paint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463AD26C510E0007CEEAB /* shape_paint_base.hpp */; };
+		04F464A226C510E1007CEEAB /* solid_color_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463AE26C510E0007CEEAB /* solid_color_base.hpp */; };
+		04F464A326C510E1007CEEAB /* trim_path_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463AF26C510E0007CEEAB /* trim_path_base.hpp */; };
+		04F464A426C510E1007CEEAB /* radial_gradient_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463B026C510E0007CEEAB /* radial_gradient_base.hpp */; };
+		04F464A526C510E1007CEEAB /* gradient_stop_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463B126C510E0007CEEAB /* gradient_stop_base.hpp */; };
+		04F464A626C510E1007CEEAB /* parametric_path_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463B226C510E0007CEEAB /* parametric_path_base.hpp */; };
+		04F464A726C510E1007CEEAB /* cubic_asymmetric_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463B326C510E0007CEEAB /* cubic_asymmetric_vertex_base.hpp */; };
+		04F464A826C510E1007CEEAB /* cubic_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463B426C510E0007CEEAB /* cubic_vertex_base.hpp */; };
+		04F464A926C510E1007CEEAB /* ellipse_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463B526C510E0007CEEAB /* ellipse_base.hpp */; };
+		04F464AA26C510E1007CEEAB /* points_path_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463B626C510E0007CEEAB /* points_path_base.hpp */; };
+		04F464AB26C510E1007CEEAB /* triangle_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463B726C510E0007CEEAB /* triangle_base.hpp */; };
+		04F464AC26C510E1007CEEAB /* shape_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463B826C510E0007CEEAB /* shape_base.hpp */; };
+		04F464AD26C510E1007CEEAB /* rectangle_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463B926C510E0007CEEAB /* rectangle_base.hpp */; };
+		04F464AE26C510E1007CEEAB /* cubic_mirrored_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463BA26C510E0007CEEAB /* cubic_mirrored_vertex_base.hpp */; };
+		04F464AF26C510E1007CEEAB /* star_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463BB26C510E0007CEEAB /* star_base.hpp */; };
+		04F464B026C510E1007CEEAB /* straight_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463BC26C510E0007CEEAB /* straight_vertex_base.hpp */; };
+		04F464B126C510E1007CEEAB /* path_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463BD26C510E0007CEEAB /* path_base.hpp */; };
+		04F464B226C510E1007CEEAB /* polygon_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463BE26C510E0007CEEAB /* polygon_base.hpp */; };
+		04F464B326C510E1007CEEAB /* cubic_detached_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463BF26C510E0007CEEAB /* cubic_detached_vertex_base.hpp */; };
+		04F464B426C510E1007CEEAB /* clipping_shape_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463C026C510E0007CEEAB /* clipping_shape_base.hpp */; };
+		04F464B526C510E1007CEEAB /* path_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463C126C510E0007CEEAB /* path_vertex_base.hpp */; };
+		04F464B626C510E1007CEEAB /* container_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463C226C510E0007CEEAB /* container_component_base.hpp */; };
+		04F464B726C510E1007CEEAB /* component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463C326C510E0007CEEAB /* component_base.hpp */; };
+		04F464B826C510E1007CEEAB /* weight_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463C526C510E0007CEEAB /* weight_base.hpp */; };
+		04F464B926C510E1007CEEAB /* root_bone_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463C626C510E0007CEEAB /* root_bone_base.hpp */; };
+		04F464BA26C510E1007CEEAB /* cubic_weight_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463C726C510E0007CEEAB /* cubic_weight_base.hpp */; };
+		04F464BB26C510E1007CEEAB /* bone_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463C826C510E0007CEEAB /* bone_base.hpp */; };
+		04F464BC26C510E1007CEEAB /* skin_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463C926C510E0007CEEAB /* skin_base.hpp */; };
+		04F464BD26C510E1007CEEAB /* tendon_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463CA26C510E0007CEEAB /* tendon_base.hpp */; };
+		04F464BE26C510E1007CEEAB /* skeletal_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463CB26C510E0007CEEAB /* skeletal_component_base.hpp */; };
+		04F464BF26C510E1007CEEAB /* draw_target_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463CC26C510E0007CEEAB /* draw_target_base.hpp */; };
+		04F464C026C510E1007CEEAB /* backboard_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463CD26C510E0007CEEAB /* backboard_base.hpp */; };
+		04F464C126C510E1007CEEAB /* drawable_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463CE26C510E0007CEEAB /* drawable_base.hpp */; };
+		04F464C226C510E1007CEEAB /* backboard.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463CF26C510E0007CEEAB /* backboard.hpp */; };
+		04F464C326C510E1007CEEAB /* reader.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F463D126C510E0007CEEAB /* reader.h */; };
+		04F464C426C510E1007CEEAB /* core_color_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463D326C510E0007CEEAB /* core_color_type.hpp */; };
+		04F464C526C510E1007CEEAB /* core_uint_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463D426C510E0007CEEAB /* core_uint_type.hpp */; };
+		04F464C626C510E1007CEEAB /* core_double_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463D526C510E0007CEEAB /* core_double_type.hpp */; };
+		04F464C726C510E1007CEEAB /* core_string_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463D626C510E0007CEEAB /* core_string_type.hpp */; };
+		04F464C826C510E1007CEEAB /* core_bool_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463D726C510E0007CEEAB /* core_bool_type.hpp */; };
+		04F464C926C510E1007CEEAB /* binary_reader.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463D826C510E0007CEEAB /* binary_reader.hpp */; };
+		04F464CA26C510E1007CEEAB /* status_code.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463D926C510E0007CEEAB /* status_code.hpp */; };
+		04F464CB26C510E1007CEEAB /* translation_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463DB26C510E0007CEEAB /* translation_constraint.hpp */; };
+		04F464CC26C510E1007CEEAB /* scale_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463DC26C510E0007CEEAB /* scale_constraint.hpp */; };
+		04F464CD26C510E1007CEEAB /* targeted_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463DD26C510E0007CEEAB /* targeted_constraint.hpp */; };
+		04F464CE26C510E1007CEEAB /* constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463DE26C510E0007CEEAB /* constraint.hpp */; };
+		04F464CF26C510E1007CEEAB /* rotation_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463DF26C510E0007CEEAB /* rotation_constraint.hpp */; };
+		04F464D026C510E1007CEEAB /* transform_component_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463E026C510E0007CEEAB /* transform_component_constraint.hpp */; };
+		04F464D126C510E1007CEEAB /* transform_space_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463E126C510E0007CEEAB /* transform_space_constraint.hpp */; };
+		04F464D226C510E1007CEEAB /* ik_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463E226C510E0007CEEAB /* ik_constraint.hpp */; };
+		04F464D326C510E1007CEEAB /* transform_component_constraint_y.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463E326C510E0007CEEAB /* transform_component_constraint_y.hpp */; };
+		04F464D426C510E1007CEEAB /* transform_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463E426C510E0007CEEAB /* transform_constraint.hpp */; };
+		04F464D526C510E1007CEEAB /* distance_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463E526C510E0007CEEAB /* distance_constraint.hpp */; };
+		04F464D626C510E1007CEEAB /* component_dirt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463E626C510E0007CEEAB /* component_dirt.hpp */; };
+		04F464D726C510E1007CEEAB /* renderer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463E726C510E0007CEEAB /* renderer.hpp */; };
+		04F464D826C510E1007CEEAB /* draw_target_placement.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463E826C510E0007CEEAB /* draw_target_placement.hpp */; };
+		04F464D926C510E1007CEEAB /* state_transition_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463EA26C510E0007CEEAB /* state_transition_importer.hpp */; };
+		04F464DA26C510E1007CEEAB /* state_machine_layer_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463EB26C510E0007CEEAB /* state_machine_layer_importer.hpp */; };
+		04F464DB26C510E1007CEEAB /* keyed_property_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463EC26C510E0007CEEAB /* keyed_property_importer.hpp */; };
+		04F464DC26C510E1007CEEAB /* keyed_object_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463ED26C510E0007CEEAB /* keyed_object_importer.hpp */; };
+		04F464DD26C510E1007CEEAB /* linear_animation_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463EE26C510E0007CEEAB /* linear_animation_importer.hpp */; };
+		04F464DE26C510E1007CEEAB /* import_stack.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463EF26C510E0007CEEAB /* import_stack.hpp */; };
+		04F464DF26C510E1007CEEAB /* layer_state_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463F026C510E0007CEEAB /* layer_state_importer.hpp */; };
+		04F464E026C510E1007CEEAB /* artboard_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463F126C510E0007CEEAB /* artboard_importer.hpp */; };
+		04F464E126C510E1007CEEAB /* state_machine_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463F226C510E0007CEEAB /* state_machine_importer.hpp */; };
+		04F464E226C510E1007CEEAB /* world_transform_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463F326C510E0007CEEAB /* world_transform_component.hpp */; };
+		04F464E326C510E1007CEEAB /* draw_target.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463F426C510E0007CEEAB /* draw_target.hpp */; };
+		04F464E426C510E1007CEEAB /* runtime_header.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463F526C510E0007CEEAB /* runtime_header.hpp */; };
+		04F464E526C510E1007CEEAB /* file.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463F626C510E0007CEEAB /* file.hpp */; };
+		04F464E626C510E1007CEEAB /* container_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463F726C510E0007CEEAB /* container_component.hpp */; };
+		04F464E726C510E1007CEEAB /* transition_bool_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463F926C510E0007CEEAB /* transition_bool_condition.hpp */; };
+		04F464E826C510E1007CEEAB /* cubic_interpolator.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463FA26C510E0007CEEAB /* cubic_interpolator.hpp */; };
+		04F464E926C510E1007CEEAB /* keyed_property.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463FB26C510E0007CEEAB /* keyed_property.hpp */; };
+		04F464EA26C510E1007CEEAB /* state_machine_input.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463FC26C510E0007CEEAB /* state_machine_input.hpp */; };
+		04F464EB26C510E1007CEEAB /* layer_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463FD26C510E0007CEEAB /* layer_state.hpp */; };
+		04F464EC26C510E1007CEEAB /* state_transition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463FE26C510E0007CEEAB /* state_transition.hpp */; };
+		04F464ED26C510E1007CEEAB /* system_state_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F463FF26C510E0007CEEAB /* system_state_instance.hpp */; };
+		04F464EE26C510E1007CEEAB /* state_machine_trigger.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4640026C510E0007CEEAB /* state_machine_trigger.hpp */; };
+		04F464EF26C510E1007CEEAB /* keyframe_id.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4640126C510E0007CEEAB /* keyframe_id.hpp */; };
+		04F464F026C510E1007CEEAB /* blend_state_transition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4640226C510E0007CEEAB /* blend_state_transition.hpp */; };
+		04F464F126C510E1007CEEAB /* transition_number_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4640326C510E0007CEEAB /* transition_number_condition.hpp */; };
+		04F464F226C510E1007CEEAB /* state_machine_number.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4640426C510E0007CEEAB /* state_machine_number.hpp */; };
+		04F464F326C510E1007CEEAB /* animation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4640526C510E0007CEEAB /* animation.hpp */; };
+		04F464F426C510E1007CEEAB /* keyframe.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4640626C510E0007CEEAB /* keyframe.hpp */; };
+		04F464F526C510E1007CEEAB /* blend_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4640726C510E0007CEEAB /* blend_state.hpp */; };
+		04F464F626C510E1007CEEAB /* state_machine_layer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4640826C510E0007CEEAB /* state_machine_layer.hpp */; };
+		04F464F726C510E1007CEEAB /* blend_animation_1d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4640926C510E0007CEEAB /* blend_animation_1d.hpp */; };
+		04F464F826C510E1007CEEAB /* state_machine_layer_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4640A26C510E0007CEEAB /* state_machine_layer_component.hpp */; };
+		04F464F926C510E1007CEEAB /* blend_state_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4640B26C510E0007CEEAB /* blend_state_instance.hpp */; };
+		04F464FA26C510E1007CEEAB /* state_machine_bool.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4640C26C510E0007CEEAB /* state_machine_bool.hpp */; };
+		04F464FB26C510E1007CEEAB /* blend_state_1d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4640D26C510E0007CEEAB /* blend_state_1d.hpp */; };
+		04F464FC26C510E1007CEEAB /* state_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4640E26C510E0007CEEAB /* state_instance.hpp */; };
+		04F464FD26C510E1007CEEAB /* keyed_object.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4640F26C510E0007CEEAB /* keyed_object.hpp */; };
+		04F464FE26C510E1007CEEAB /* state_machine_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4641026C510E0007CEEAB /* state_machine_component.hpp */; };
+		04F464FF26C510E1007CEEAB /* state_machine.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4641126C510E0007CEEAB /* state_machine.hpp */; };
+		04F4650026C510E1007CEEAB /* blend_state_1d_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4641226C510E0007CEEAB /* blend_state_1d_instance.hpp */; };
+		04F4650126C510E1007CEEAB /* keyframe_bool.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4641326C510E0007CEEAB /* keyframe_bool.hpp */; };
+		04F4650226C510E1007CEEAB /* state_machine_input_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4641426C510E0007CEEAB /* state_machine_input_instance.hpp */; };
+		04F4650326C510E1007CEEAB /* transition_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4641526C510E0007CEEAB /* transition_condition.hpp */; };
+		04F4650426C510E1007CEEAB /* transition_value_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4641626C510E0007CEEAB /* transition_value_condition.hpp */; };
+		04F4650526C510E1007CEEAB /* animation_state_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4641726C510E0007CEEAB /* animation_state_instance.hpp */; };
+		04F4650626C510E1007CEEAB /* linear_animation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4641826C510E0007CEEAB /* linear_animation.hpp */; };
+		04F4650726C510E1007CEEAB /* linear_animation_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4641926C510E0007CEEAB /* linear_animation_instance.hpp */; };
+		04F4650826C510E1007CEEAB /* transition_condition_op.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4641A26C510E0007CEEAB /* transition_condition_op.hpp */; };
+		04F4650926C510E1007CEEAB /* blend_state_direct_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4641B26C510E0007CEEAB /* blend_state_direct_instance.hpp */; };
+		04F4650A26C510E1007CEEAB /* keyframe_double.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4641C26C510E0007CEEAB /* keyframe_double.hpp */; };
+		04F4650B26C510E1007CEEAB /* blend_animation_direct.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4641D26C510E0007CEEAB /* blend_animation_direct.hpp */; };
+		04F4650C26C510E1007CEEAB /* loop.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4641E26C510E0007CEEAB /* loop.hpp */; };
+		04F4650D26C510E1007CEEAB /* keyframe_color.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4641F26C510E0007CEEAB /* keyframe_color.hpp */; };
+		04F4650E26C510E1007CEEAB /* entry_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4642026C510E0007CEEAB /* entry_state.hpp */; };
+		04F4650F26C510E1007CEEAB /* blend_animation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4642126C510E0007CEEAB /* blend_animation.hpp */; };
+		04F4651026C510E1007CEEAB /* state_machine_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4642226C510E0007CEEAB /* state_machine_instance.hpp */; };
+		04F4651126C510E1007CEEAB /* state_transition_flags.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4642326C510E0007CEEAB /* state_transition_flags.hpp */; };
+		04F4651226C510E1007CEEAB /* exit_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4642426C510E0007CEEAB /* exit_state.hpp */; };
+		04F4651326C510E1007CEEAB /* any_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4642526C510E0007CEEAB /* any_state.hpp */; };
+		04F4651426C510E1007CEEAB /* animation_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4642626C510E0007CEEAB /* animation_state.hpp */; };
+		04F4651526C510E1007CEEAB /* blend_state_direct.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4642726C510E0007CEEAB /* blend_state_direct.hpp */; };
+		04F4651626C510E1007CEEAB /* transition_trigger_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4642826C510E0007CEEAB /* transition_trigger_condition.hpp */; };
+		04F4651726C510E1007CEEAB /* transform_space.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4642926C510E0007CEEAB /* transform_space.hpp */; };
+		04F4651826C510E1007CEEAB /* straight_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4642B26C510E0007CEEAB /* straight_vertex.hpp */; };
+		04F4651926C510E1007CEEAB /* stroke_cap.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4642D26C510E0007CEEAB /* stroke_cap.hpp */; };
+		04F4651A26C510E1007CEEAB /* gradient_stop.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4642E26C510E0007CEEAB /* gradient_stop.hpp */; };
+		04F4651B26C510E1007CEEAB /* stroke.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4642F26C510E0007CEEAB /* stroke.hpp */; };
+		04F4651C26C510E1007CEEAB /* shape_paint_mutator.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4643026C510E0007CEEAB /* shape_paint_mutator.hpp */; };
+		04F4651D26C510E1007CEEAB /* blend_mode.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4643126C510E0007CEEAB /* blend_mode.hpp */; };
+		04F4651E26C510E1007CEEAB /* shape_paint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4643226C510E0007CEEAB /* shape_paint.hpp */; };
+		04F4651F26C510E1007CEEAB /* stroke_join.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4643326C510E0007CEEAB /* stroke_join.hpp */; };
+		04F4652026C510E1007CEEAB /* fill.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4643426C510E0007CEEAB /* fill.hpp */; };
+		04F4652126C510E1007CEEAB /* radial_gradient.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4643526C510E0007CEEAB /* radial_gradient.hpp */; };
+		04F4652226C510E1007CEEAB /* trim_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4643626C510E0007CEEAB /* trim_path.hpp */; };
+		04F4652326C510E1007CEEAB /* color.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4643726C510E0007CEEAB /* color.hpp */; };
+		04F4652426C510E1007CEEAB /* solid_color.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4643826C510E0007CEEAB /* solid_color.hpp */; };
+		04F4652526C510E1007CEEAB /* linear_gradient.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4643926C510E0007CEEAB /* linear_gradient.hpp */; };
+		04F4652626C510E1007CEEAB /* stroke_effect.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4643A26C510E0007CEEAB /* stroke_effect.hpp */; };
+		04F4652726C510E1007CEEAB /* path_composer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4643B26C510E0007CEEAB /* path_composer.hpp */; };
+		04F4652826C510E1007CEEAB /* shape_paint_container.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4643C26C510E0007CEEAB /* shape_paint_container.hpp */; };
+		04F4652926C510E1007CEEAB /* cubic_mirrored_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4643D26C510E0007CEEAB /* cubic_mirrored_vertex.hpp */; };
+		04F4652A26C510E1007CEEAB /* path_space.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4643E26C510E0007CEEAB /* path_space.hpp */; };
+		04F4652B26C510E1007CEEAB /* ellipse.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4643F26C510E0007CEEAB /* ellipse.hpp */; };
+		04F4652C26C510E1007CEEAB /* clipping_shape.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4644026C510E0007CEEAB /* clipping_shape.hpp */; };
+		04F4652D26C510E1007CEEAB /* metrics_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4644126C510E0007CEEAB /* metrics_path.hpp */; };
+		04F4652E26C510E1007CEEAB /* cubic_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4644226C510E0007CEEAB /* cubic_vertex.hpp */; };
+		04F4652F26C510E1007CEEAB /* shape.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4644326C510E0007CEEAB /* shape.hpp */; };
+		04F4653026C510E1007CEEAB /* triangle.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4644426C510E0007CEEAB /* triangle.hpp */; };
+		04F4653126C510E1007CEEAB /* path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4644526C510E0007CEEAB /* path.hpp */; };
+		04F4653226C510E1007CEEAB /* polygon.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4644626C510E0007CEEAB /* polygon.hpp */; };
+		04F4653326C510E1007CEEAB /* path_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4644726C510E0007CEEAB /* path_vertex.hpp */; };
+		04F4653426C510E1007CEEAB /* parametric_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4644826C510E0007CEEAB /* parametric_path.hpp */; };
+		04F4653526C510E1007CEEAB /* rectangle.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4644926C510E0007CEEAB /* rectangle.hpp */; };
+		04F4653626C510E1007CEEAB /* points_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4644A26C510E0007CEEAB /* points_path.hpp */; };
+		04F4653726C510E1007CEEAB /* star.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4644B26C510E0007CEEAB /* star.hpp */; };
+		04F4653826C510E1007CEEAB /* cubic_asymmetric_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4644C26C510E0007CEEAB /* cubic_asymmetric_vertex.hpp */; };
+		04F4653926C510E1007CEEAB /* cubic_detached_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4644D26C510E0007CEEAB /* cubic_detached_vertex.hpp */; };
+		04F4653A26C510E1007CEEAB /* vec2d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4644F26C510E0007CEEAB /* vec2d.hpp */; };
+		04F4653B26C510E1007CEEAB /* mat2d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4645026C510E0007CEEAB /* mat2d.hpp */; };
+		04F4653C26C510E1007CEEAB /* aabb.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4645126C510E0007CEEAB /* aabb.hpp */; };
+		04F4653D26C510E1007CEEAB /* color.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4645226C510E0007CEEAB /* color.hpp */; };
+		04F4653E26C510E1007CEEAB /* transform_components.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4645326C510E0007CEEAB /* transform_components.hpp */; };
+		04F4653F26C510E1007CEEAB /* circle_constant.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4645426C510E0007CEEAB /* circle_constant.hpp */; };
+		04F4654026C510E1007CEEAB /* command_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4645526C510E0007CEEAB /* command_path.hpp */; };
+		04F4654126C510E1007CEEAB /* component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4645626C510E0007CEEAB /* component.hpp */; };
+		04F4654226C510E1007CEEAB /* node.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4645726C510E0007CEEAB /* node.hpp */; };
+		04F4654326C510E1007CEEAB /* layout.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4645826C510E0007CEEAB /* layout.hpp */; };
+		04F4654426C510E1007CEEAB /* drawable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4645926C510E0007CEEAB /* drawable.hpp */; };
+		04F4654526C510E1007CEEAB /* artboard.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4645A26C510E0007CEEAB /* artboard.hpp */; };
+		04F4654626C510E1007CEEAB /* dependency_sorter.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4645B26C510E0007CEEAB /* dependency_sorter.hpp */; };
+		04F4654726C510E1007CEEAB /* core_context.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4645C26C510E0007CEEAB /* core_context.hpp */; };
+		04F4654826C510E1007CEEAB /* tendon.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4645E26C510E0007CEEAB /* tendon.hpp */; };
+		04F4654926C510E1007CEEAB /* skeletal_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4645F26C510E0007CEEAB /* skeletal_component.hpp */; };
+		04F4654A26C510E1007CEEAB /* weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4646026C510E0007CEEAB /* weight.hpp */; };
+		04F4654B26C510E1007CEEAB /* skin.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4646126C510E0007CEEAB /* skin.hpp */; };
+		04F4654C26C510E1007CEEAB /* root_bone.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4646226C510E0007CEEAB /* root_bone.hpp */; };
+		04F4654D26C510E1007CEEAB /* bone.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4646326C510E0007CEEAB /* bone.hpp */; };
+		04F4654E26C510E1007CEEAB /* skinnable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4646426C510E0007CEEAB /* skinnable.hpp */; };
+		04F4654F26C510E1007CEEAB /* cubic_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4646526C510E0007CEEAB /* cubic_weight.hpp */; };
+		04F4655026C510E1007CEEAB /* draw_rules.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4646626C510E0007CEEAB /* draw_rules.hpp */; };
+		04F4655126C510E1007CEEAB /* core.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4646726C510E0007CEEAB /* core.hpp */; };
+		04F4655226C510E1007CEEAB /* transform_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4646826C510E0007CEEAB /* transform_component.hpp */; };
+		04F4655626C51416007CEEAB /* translation_constraint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F4655326C51416007CEEAB /* translation_constraint.cpp */; };
+		04F4655726C51416007CEEAB /* scale_constraint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F4655426C51416007CEEAB /* scale_constraint.cpp */; };
+		04F4655826C51416007CEEAB /* rotation_constraint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F4655526C51416007CEEAB /* rotation_constraint.cpp */; };
+		04F4655A26C51422007CEEAB /* world_transform_component.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F4655926C51422007CEEAB /* world_transform_component.cpp */; };
+		04F4655E26C514A4007CEEAB /* rotation_constraint_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F4655B26C514A3007CEEAB /* rotation_constraint_base.cpp */; };
+		04F4655F26C514A4007CEEAB /* translation_constraint_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F4655C26C514A3007CEEAB /* translation_constraint_base.cpp */; };
+		04F4656026C514A4007CEEAB /* scale_constraint_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F4655D26C514A3007CEEAB /* scale_constraint_base.cpp */; };
+		04F4656226C514AC007CEEAB /* keyframe_bool_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F4656126C514AC007CEEAB /* keyframe_bool_base.cpp */; };
+		04F4656426C514B7007CEEAB /* keyframe_bool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F4656326C514B7007CEEAB /* keyframe_bool.cpp */; };
 		C9002A20263C76080011556B /* RiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9002A1F263C76080011556B /* RiveView.swift */; };
 		C9161A81263CBCBC007749A1 /* RiveRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9C73ED124FC478800EF9516 /* RiveRuntime.framework */; };
 		C9601F2B250C25930032AA07 /* RiveRenderer.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9601F2A250C25930032AA07 /* RiveRenderer.mm */; };
@@ -504,224 +529,249 @@
 		04F1C92C26A84B8700CEE6BE /* blend_state_transition_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = blend_state_transition_base.cpp; sourceTree = "<group>"; };
 		04F1C92D26A84B8700CEE6BE /* blend_state_1d_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = blend_state_1d_base.cpp; sourceTree = "<group>"; };
 		04F1C92E26A84B8700CEE6BE /* blend_state_direct_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = blend_state_direct_base.cpp; sourceTree = "<group>"; };
-		04F460CC26C4030C007CEEAB /* core_registry.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_registry.hpp; sourceTree = "<group>"; };
-		04F460CD26C4030C007CEEAB /* node_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = node_base.hpp; sourceTree = "<group>"; };
-		04F460CE26C4030C007CEEAB /* transform_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_component_base.hpp; sourceTree = "<group>"; };
-		04F460D026C4030C007CEEAB /* constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = constraint_base.hpp; sourceTree = "<group>"; };
-		04F460D126C4030C007CEEAB /* targeted_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = targeted_constraint_base.hpp; sourceTree = "<group>"; };
-		04F460D226C4030C007CEEAB /* ik_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ik_constraint_base.hpp; sourceTree = "<group>"; };
-		04F460D326C4030C007CEEAB /* transform_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_constraint_base.hpp; sourceTree = "<group>"; };
-		04F460D426C4030C007CEEAB /* distance_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = distance_constraint_base.hpp; sourceTree = "<group>"; };
-		04F460D526C4030C007CEEAB /* artboard_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = artboard_base.hpp; sourceTree = "<group>"; };
-		04F460D626C4030C007CEEAB /* draw_rules_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_rules_base.hpp; sourceTree = "<group>"; };
-		04F460D826C4030C007CEEAB /* blend_animation_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_base.hpp; sourceTree = "<group>"; };
-		04F460D926C4030C007CEEAB /* keyframe_color_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_color_base.hpp; sourceTree = "<group>"; };
-		04F460DA26C4030C007CEEAB /* keyed_property_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_property_base.hpp; sourceTree = "<group>"; };
-		04F460DB26C4030C007CEEAB /* keyframe_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_base.hpp; sourceTree = "<group>"; };
-		04F460DC26C4030C007CEEAB /* animation_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_state_base.hpp; sourceTree = "<group>"; };
-		04F460DD26C4030C007CEEAB /* animation_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_base.hpp; sourceTree = "<group>"; };
-		04F460DE26C4030C007CEEAB /* blend_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_base.hpp; sourceTree = "<group>"; };
-		04F460DF26C4030C007CEEAB /* transition_number_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_number_condition_base.hpp; sourceTree = "<group>"; };
-		04F460E026C4030C007CEEAB /* cubic_interpolator_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_interpolator_base.hpp; sourceTree = "<group>"; };
-		04F460E126C4030C007CEEAB /* linear_animation_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_animation_base.hpp; sourceTree = "<group>"; };
-		04F460E226C4030C007CEEAB /* entry_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = entry_state_base.hpp; sourceTree = "<group>"; };
-		04F460E326C4030C007CEEAB /* layer_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = layer_state_base.hpp; sourceTree = "<group>"; };
-		04F460E426C4030C007CEEAB /* state_machine_layer_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer_component_base.hpp; sourceTree = "<group>"; };
-		04F460E526C4030C007CEEAB /* blend_state_direct_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_direct_base.hpp; sourceTree = "<group>"; };
-		04F460E626C4030C007CEEAB /* state_machine_layer_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer_base.hpp; sourceTree = "<group>"; };
-		04F460E726C4030C007CEEAB /* keyframe_id_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_id_base.hpp; sourceTree = "<group>"; };
-		04F460E826C4030C007CEEAB /* blend_animation_1d_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_1d_base.hpp; sourceTree = "<group>"; };
-		04F460E926C4030C007CEEAB /* keyed_object_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_object_base.hpp; sourceTree = "<group>"; };
-		04F460EA26C4030C007CEEAB /* transition_value_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_value_condition_base.hpp; sourceTree = "<group>"; };
-		04F460EB26C4030C007CEEAB /* state_machine_number_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_number_base.hpp; sourceTree = "<group>"; };
-		04F460EC26C4030C007CEEAB /* state_transition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_transition_base.hpp; sourceTree = "<group>"; };
-		04F460ED26C4030C007CEEAB /* keyframe_double_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_double_base.hpp; sourceTree = "<group>"; };
-		04F460EE26C4030C007CEEAB /* state_machine_bool_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_bool_base.hpp; sourceTree = "<group>"; };
-		04F460EF26C4030C007CEEAB /* blend_state_transition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_transition_base.hpp; sourceTree = "<group>"; };
-		04F460F026C4030C007CEEAB /* blend_animation_direct_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_direct_base.hpp; sourceTree = "<group>"; };
-		04F460F126C4030C007CEEAB /* transition_bool_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_bool_condition_base.hpp; sourceTree = "<group>"; };
-		04F460F226C4030C007CEEAB /* transition_trigger_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_trigger_condition_base.hpp; sourceTree = "<group>"; };
-		04F460F326C4030C007CEEAB /* state_machine_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_component_base.hpp; sourceTree = "<group>"; };
-		04F460F426C4030C007CEEAB /* any_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = any_state_base.hpp; sourceTree = "<group>"; };
-		04F460F526C4030C007CEEAB /* transition_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_condition_base.hpp; sourceTree = "<group>"; };
-		04F460F626C4030C007CEEAB /* state_machine_input_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_input_base.hpp; sourceTree = "<group>"; };
-		04F460F726C4030D007CEEAB /* blend_state_1d_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_1d_base.hpp; sourceTree = "<group>"; };
-		04F460F826C4030D007CEEAB /* state_machine_trigger_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_trigger_base.hpp; sourceTree = "<group>"; };
-		04F460F926C4030D007CEEAB /* state_machine_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_base.hpp; sourceTree = "<group>"; };
-		04F460FA26C4030D007CEEAB /* exit_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = exit_state_base.hpp; sourceTree = "<group>"; };
-		04F460FD26C4030D007CEEAB /* linear_gradient_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_gradient_base.hpp; sourceTree = "<group>"; };
-		04F460FE26C4030D007CEEAB /* stroke_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_base.hpp; sourceTree = "<group>"; };
-		04F460FF26C4030D007CEEAB /* fill_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fill_base.hpp; sourceTree = "<group>"; };
-		04F4610026C4030D007CEEAB /* shape_paint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint_base.hpp; sourceTree = "<group>"; };
-		04F4610126C4030D007CEEAB /* solid_color_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = solid_color_base.hpp; sourceTree = "<group>"; };
-		04F4610226C4030D007CEEAB /* trim_path_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = trim_path_base.hpp; sourceTree = "<group>"; };
-		04F4610326C4030D007CEEAB /* radial_gradient_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = radial_gradient_base.hpp; sourceTree = "<group>"; };
-		04F4610426C4030D007CEEAB /* gradient_stop_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = gradient_stop_base.hpp; sourceTree = "<group>"; };
-		04F4610526C4030D007CEEAB /* parametric_path_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = parametric_path_base.hpp; sourceTree = "<group>"; };
-		04F4610626C4030D007CEEAB /* cubic_asymmetric_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_asymmetric_vertex_base.hpp; sourceTree = "<group>"; };
-		04F4610726C4030D007CEEAB /* cubic_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_vertex_base.hpp; sourceTree = "<group>"; };
-		04F4610826C4030D007CEEAB /* ellipse_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ellipse_base.hpp; sourceTree = "<group>"; };
-		04F4610926C4030D007CEEAB /* points_path_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = points_path_base.hpp; sourceTree = "<group>"; };
-		04F4610A26C4030D007CEEAB /* triangle_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = triangle_base.hpp; sourceTree = "<group>"; };
-		04F4610B26C4030D007CEEAB /* shape_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_base.hpp; sourceTree = "<group>"; };
-		04F4610C26C4030D007CEEAB /* rectangle_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = rectangle_base.hpp; sourceTree = "<group>"; };
-		04F4610D26C4030D007CEEAB /* cubic_mirrored_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_mirrored_vertex_base.hpp; sourceTree = "<group>"; };
-		04F4610E26C4030D007CEEAB /* star_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = star_base.hpp; sourceTree = "<group>"; };
-		04F4610F26C4030D007CEEAB /* straight_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = straight_vertex_base.hpp; sourceTree = "<group>"; };
-		04F4611026C4030D007CEEAB /* path_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_base.hpp; sourceTree = "<group>"; };
-		04F4611126C4030D007CEEAB /* polygon_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = polygon_base.hpp; sourceTree = "<group>"; };
-		04F4611226C4030D007CEEAB /* cubic_detached_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_detached_vertex_base.hpp; sourceTree = "<group>"; };
-		04F4611326C4030D007CEEAB /* clipping_shape_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = clipping_shape_base.hpp; sourceTree = "<group>"; };
-		04F4611426C4030D007CEEAB /* path_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_vertex_base.hpp; sourceTree = "<group>"; };
-		04F4611526C4030D007CEEAB /* container_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = container_component_base.hpp; sourceTree = "<group>"; };
-		04F4611626C4030D007CEEAB /* component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = component_base.hpp; sourceTree = "<group>"; };
-		04F4611826C4030D007CEEAB /* weight_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = weight_base.hpp; sourceTree = "<group>"; };
-		04F4611926C4030D007CEEAB /* root_bone_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = root_bone_base.hpp; sourceTree = "<group>"; };
-		04F4611A26C4030D007CEEAB /* cubic_weight_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_weight_base.hpp; sourceTree = "<group>"; };
-		04F4611B26C4030D007CEEAB /* bone_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bone_base.hpp; sourceTree = "<group>"; };
-		04F4611C26C4030D007CEEAB /* skin_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skin_base.hpp; sourceTree = "<group>"; };
-		04F4611D26C4030D007CEEAB /* tendon_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = tendon_base.hpp; sourceTree = "<group>"; };
-		04F4611E26C4030D007CEEAB /* skeletal_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skeletal_component_base.hpp; sourceTree = "<group>"; };
-		04F4611F26C4030D007CEEAB /* draw_target_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_target_base.hpp; sourceTree = "<group>"; };
-		04F4612026C4030D007CEEAB /* backboard_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = backboard_base.hpp; sourceTree = "<group>"; };
-		04F4612126C4030D007CEEAB /* drawable_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = drawable_base.hpp; sourceTree = "<group>"; };
-		04F4612226C4030D007CEEAB /* backboard.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = backboard.hpp; sourceTree = "<group>"; };
-		04F4612426C4030D007CEEAB /* reader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reader.h; sourceTree = "<group>"; };
-		04F4612626C4030D007CEEAB /* core_color_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_color_type.hpp; sourceTree = "<group>"; };
-		04F4612726C4030D007CEEAB /* core_uint_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_uint_type.hpp; sourceTree = "<group>"; };
-		04F4612826C4030D007CEEAB /* core_double_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_double_type.hpp; sourceTree = "<group>"; };
-		04F4612926C4030D007CEEAB /* core_string_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_string_type.hpp; sourceTree = "<group>"; };
-		04F4612A26C4030D007CEEAB /* core_bool_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_bool_type.hpp; sourceTree = "<group>"; };
-		04F4612B26C4030D007CEEAB /* binary_reader.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = binary_reader.hpp; sourceTree = "<group>"; };
-		04F4612C26C4030D007CEEAB /* status_code.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = status_code.hpp; sourceTree = "<group>"; };
-		04F4612E26C4030D007CEEAB /* targeted_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = targeted_constraint.hpp; sourceTree = "<group>"; };
-		04F4612F26C4030D007CEEAB /* constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = constraint.hpp; sourceTree = "<group>"; };
-		04F4613026C4030D007CEEAB /* ik_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ik_constraint.hpp; sourceTree = "<group>"; };
-		04F4613126C4030D007CEEAB /* transform_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_constraint.hpp; sourceTree = "<group>"; };
-		04F4613226C4030D007CEEAB /* distance_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = distance_constraint.hpp; sourceTree = "<group>"; };
-		04F4613326C4030D007CEEAB /* component_dirt.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = component_dirt.hpp; sourceTree = "<group>"; };
-		04F4613426C4030D007CEEAB /* renderer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = renderer.hpp; sourceTree = "<group>"; };
-		04F4613526C4030D007CEEAB /* draw_target_placement.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_target_placement.hpp; sourceTree = "<group>"; };
-		04F4613726C4030D007CEEAB /* state_transition_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_transition_importer.hpp; sourceTree = "<group>"; };
-		04F4613826C4030D007CEEAB /* state_machine_layer_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer_importer.hpp; sourceTree = "<group>"; };
-		04F4613926C4030D007CEEAB /* keyed_property_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_property_importer.hpp; sourceTree = "<group>"; };
-		04F4613A26C4030D007CEEAB /* keyed_object_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_object_importer.hpp; sourceTree = "<group>"; };
-		04F4613B26C4030D007CEEAB /* linear_animation_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_animation_importer.hpp; sourceTree = "<group>"; };
-		04F4613C26C4030D007CEEAB /* import_stack.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = import_stack.hpp; sourceTree = "<group>"; };
-		04F4613D26C4030D007CEEAB /* layer_state_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = layer_state_importer.hpp; sourceTree = "<group>"; };
-		04F4613E26C4030D007CEEAB /* artboard_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = artboard_importer.hpp; sourceTree = "<group>"; };
-		04F4613F26C4030D007CEEAB /* state_machine_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_importer.hpp; sourceTree = "<group>"; };
-		04F4614026C4030D007CEEAB /* draw_target.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_target.hpp; sourceTree = "<group>"; };
-		04F4614126C4030D007CEEAB /* runtime_header.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = runtime_header.hpp; sourceTree = "<group>"; };
-		04F4614226C4030D007CEEAB /* file.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = file.hpp; sourceTree = "<group>"; };
-		04F4614326C4030D007CEEAB /* container_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = container_component.hpp; sourceTree = "<group>"; };
-		04F4614526C4030D007CEEAB /* transition_bool_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_bool_condition.hpp; sourceTree = "<group>"; };
-		04F4614626C4030D007CEEAB /* cubic_interpolator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_interpolator.hpp; sourceTree = "<group>"; };
-		04F4614726C4030D007CEEAB /* keyed_property.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_property.hpp; sourceTree = "<group>"; };
-		04F4614826C4030D007CEEAB /* state_machine_input.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_input.hpp; sourceTree = "<group>"; };
-		04F4614926C4030D007CEEAB /* layer_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = layer_state.hpp; sourceTree = "<group>"; };
-		04F4614A26C4030D007CEEAB /* state_transition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_transition.hpp; sourceTree = "<group>"; };
-		04F4614B26C4030D007CEEAB /* system_state_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = system_state_instance.hpp; sourceTree = "<group>"; };
-		04F4614C26C4030D007CEEAB /* state_machine_trigger.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_trigger.hpp; sourceTree = "<group>"; };
-		04F4614D26C4030D007CEEAB /* keyframe_id.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_id.hpp; sourceTree = "<group>"; };
-		04F4614E26C4030D007CEEAB /* blend_state_transition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_transition.hpp; sourceTree = "<group>"; };
-		04F4614F26C4030D007CEEAB /* transition_number_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_number_condition.hpp; sourceTree = "<group>"; };
-		04F4615026C4030D007CEEAB /* state_machine_number.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_number.hpp; sourceTree = "<group>"; };
-		04F4615126C4030D007CEEAB /* animation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation.hpp; sourceTree = "<group>"; };
-		04F4615226C4030D007CEEAB /* keyframe.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe.hpp; sourceTree = "<group>"; };
-		04F4615326C4030D007CEEAB /* blend_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state.hpp; sourceTree = "<group>"; };
-		04F4615426C4030D007CEEAB /* state_machine_layer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer.hpp; sourceTree = "<group>"; };
-		04F4615526C4030D007CEEAB /* blend_animation_1d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_1d.hpp; sourceTree = "<group>"; };
-		04F4615626C4030D007CEEAB /* state_machine_layer_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer_component.hpp; sourceTree = "<group>"; };
-		04F4615726C4030D007CEEAB /* blend_state_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_instance.hpp; sourceTree = "<group>"; };
-		04F4615826C4030D007CEEAB /* state_machine_bool.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_bool.hpp; sourceTree = "<group>"; };
-		04F4615926C4030D007CEEAB /* blend_state_1d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_1d.hpp; sourceTree = "<group>"; };
-		04F4615A26C4030D007CEEAB /* state_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_instance.hpp; sourceTree = "<group>"; };
-		04F4615B26C4030D007CEEAB /* keyed_object.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_object.hpp; sourceTree = "<group>"; };
-		04F4615C26C4030D007CEEAB /* state_machine_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_component.hpp; sourceTree = "<group>"; };
-		04F4615D26C4030D007CEEAB /* state_machine.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine.hpp; sourceTree = "<group>"; };
-		04F4615E26C4030D007CEEAB /* blend_state_1d_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_1d_instance.hpp; sourceTree = "<group>"; };
-		04F4615F26C4030D007CEEAB /* state_machine_input_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_input_instance.hpp; sourceTree = "<group>"; };
-		04F4616026C4030D007CEEAB /* transition_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_condition.hpp; sourceTree = "<group>"; };
-		04F4616126C4030D007CEEAB /* transition_value_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_value_condition.hpp; sourceTree = "<group>"; };
-		04F4616226C4030D007CEEAB /* animation_state_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_state_instance.hpp; sourceTree = "<group>"; };
-		04F4616326C4030D007CEEAB /* linear_animation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_animation.hpp; sourceTree = "<group>"; };
-		04F4616426C4030D007CEEAB /* linear_animation_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_animation_instance.hpp; sourceTree = "<group>"; };
-		04F4616526C4030D007CEEAB /* transition_condition_op.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_condition_op.hpp; sourceTree = "<group>"; };
-		04F4616626C4030D007CEEAB /* blend_state_direct_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_direct_instance.hpp; sourceTree = "<group>"; };
-		04F4616726C4030D007CEEAB /* keyframe_double.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_double.hpp; sourceTree = "<group>"; };
-		04F4616826C4030D007CEEAB /* blend_animation_direct.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_direct.hpp; sourceTree = "<group>"; };
-		04F4616926C4030D007CEEAB /* loop.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = loop.hpp; sourceTree = "<group>"; };
-		04F4616A26C4030D007CEEAB /* keyframe_color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_color.hpp; sourceTree = "<group>"; };
-		04F4616B26C4030D007CEEAB /* entry_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = entry_state.hpp; sourceTree = "<group>"; };
-		04F4616C26C4030D007CEEAB /* blend_animation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation.hpp; sourceTree = "<group>"; };
-		04F4616D26C4030D007CEEAB /* state_machine_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_instance.hpp; sourceTree = "<group>"; };
-		04F4616E26C4030D007CEEAB /* state_transition_flags.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_transition_flags.hpp; sourceTree = "<group>"; };
-		04F4616F26C4030D007CEEAB /* exit_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = exit_state.hpp; sourceTree = "<group>"; };
-		04F4617026C4030D007CEEAB /* any_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = any_state.hpp; sourceTree = "<group>"; };
-		04F4617126C4030D007CEEAB /* animation_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_state.hpp; sourceTree = "<group>"; };
-		04F4617226C4030D007CEEAB /* blend_state_direct.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_direct.hpp; sourceTree = "<group>"; };
-		04F4617326C4030D007CEEAB /* transition_trigger_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_trigger_condition.hpp; sourceTree = "<group>"; };
-		04F4617426C4030D007CEEAB /* transform_space.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_space.hpp; sourceTree = "<group>"; };
-		04F4617626C4030D007CEEAB /* straight_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = straight_vertex.hpp; sourceTree = "<group>"; };
-		04F4617826C4030D007CEEAB /* stroke_cap.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_cap.hpp; sourceTree = "<group>"; };
-		04F4617926C4030D007CEEAB /* gradient_stop.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = gradient_stop.hpp; sourceTree = "<group>"; };
-		04F4617A26C4030D007CEEAB /* stroke.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke.hpp; sourceTree = "<group>"; };
-		04F4617B26C4030D007CEEAB /* shape_paint_mutator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint_mutator.hpp; sourceTree = "<group>"; };
-		04F4617C26C4030D007CEEAB /* blend_mode.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_mode.hpp; sourceTree = "<group>"; };
-		04F4617D26C4030D007CEEAB /* shape_paint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint.hpp; sourceTree = "<group>"; };
-		04F4617E26C4030D007CEEAB /* stroke_join.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_join.hpp; sourceTree = "<group>"; };
-		04F4617F26C4030D007CEEAB /* fill.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fill.hpp; sourceTree = "<group>"; };
-		04F4618026C4030D007CEEAB /* radial_gradient.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = radial_gradient.hpp; sourceTree = "<group>"; };
-		04F4618126C4030D007CEEAB /* trim_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = trim_path.hpp; sourceTree = "<group>"; };
-		04F4618226C4030D007CEEAB /* color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = color.hpp; sourceTree = "<group>"; };
-		04F4618326C4030D007CEEAB /* solid_color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = solid_color.hpp; sourceTree = "<group>"; };
-		04F4618426C4030D007CEEAB /* linear_gradient.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_gradient.hpp; sourceTree = "<group>"; };
-		04F4618526C4030D007CEEAB /* stroke_effect.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_effect.hpp; sourceTree = "<group>"; };
-		04F4618626C4030D007CEEAB /* path_composer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_composer.hpp; sourceTree = "<group>"; };
-		04F4618726C4030D007CEEAB /* shape_paint_container.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint_container.hpp; sourceTree = "<group>"; };
-		04F4618826C4030D007CEEAB /* cubic_mirrored_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_mirrored_vertex.hpp; sourceTree = "<group>"; };
-		04F4618926C4030D007CEEAB /* path_space.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_space.hpp; sourceTree = "<group>"; };
-		04F4618A26C4030D007CEEAB /* ellipse.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ellipse.hpp; sourceTree = "<group>"; };
-		04F4618B26C4030D007CEEAB /* clipping_shape.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = clipping_shape.hpp; sourceTree = "<group>"; };
-		04F4618C26C4030D007CEEAB /* metrics_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = metrics_path.hpp; sourceTree = "<group>"; };
-		04F4618D26C4030D007CEEAB /* cubic_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_vertex.hpp; sourceTree = "<group>"; };
-		04F4618E26C4030D007CEEAB /* shape.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape.hpp; sourceTree = "<group>"; };
-		04F4618F26C4030D007CEEAB /* triangle.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = triangle.hpp; sourceTree = "<group>"; };
-		04F4619026C4030D007CEEAB /* path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path.hpp; sourceTree = "<group>"; };
-		04F4619126C4030D007CEEAB /* polygon.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = polygon.hpp; sourceTree = "<group>"; };
-		04F4619226C4030D007CEEAB /* path_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_vertex.hpp; sourceTree = "<group>"; };
-		04F4619326C4030D007CEEAB /* parametric_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = parametric_path.hpp; sourceTree = "<group>"; };
-		04F4619426C4030D007CEEAB /* rectangle.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = rectangle.hpp; sourceTree = "<group>"; };
-		04F4619526C4030D007CEEAB /* points_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = points_path.hpp; sourceTree = "<group>"; };
-		04F4619626C4030D007CEEAB /* star.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = star.hpp; sourceTree = "<group>"; };
-		04F4619726C4030D007CEEAB /* cubic_asymmetric_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_asymmetric_vertex.hpp; sourceTree = "<group>"; };
-		04F4619826C4030D007CEEAB /* cubic_detached_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_detached_vertex.hpp; sourceTree = "<group>"; };
-		04F4619A26C4030D007CEEAB /* vec2d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = vec2d.hpp; sourceTree = "<group>"; };
-		04F4619B26C4030D007CEEAB /* mat2d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = mat2d.hpp; sourceTree = "<group>"; };
-		04F4619C26C4030D007CEEAB /* aabb.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = aabb.hpp; sourceTree = "<group>"; };
-		04F4619D26C4030D007CEEAB /* color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = color.hpp; sourceTree = "<group>"; };
-		04F4619E26C4030D007CEEAB /* transform_components.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_components.hpp; sourceTree = "<group>"; };
-		04F4619F26C4030D007CEEAB /* circle_constant.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = circle_constant.hpp; sourceTree = "<group>"; };
-		04F461A026C4030D007CEEAB /* command_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = command_path.hpp; sourceTree = "<group>"; };
-		04F461A126C4030D007CEEAB /* component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = component.hpp; sourceTree = "<group>"; };
-		04F461A226C4030D007CEEAB /* node.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = node.hpp; sourceTree = "<group>"; };
-		04F461A326C4030D007CEEAB /* layout.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = layout.hpp; sourceTree = "<group>"; };
-		04F461A426C4030D007CEEAB /* drawable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = drawable.hpp; sourceTree = "<group>"; };
-		04F461A526C4030D007CEEAB /* artboard.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = artboard.hpp; sourceTree = "<group>"; };
-		04F461A626C4030D007CEEAB /* dependency_sorter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = dependency_sorter.hpp; sourceTree = "<group>"; };
-		04F461A726C4030D007CEEAB /* core_context.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_context.hpp; sourceTree = "<group>"; };
-		04F461A926C4030D007CEEAB /* tendon.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = tendon.hpp; sourceTree = "<group>"; };
-		04F461AA26C4030D007CEEAB /* skeletal_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skeletal_component.hpp; sourceTree = "<group>"; };
-		04F461AB26C4030D007CEEAB /* weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = weight.hpp; sourceTree = "<group>"; };
-		04F461AC26C4030D007CEEAB /* skin.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skin.hpp; sourceTree = "<group>"; };
-		04F461AD26C4030D007CEEAB /* root_bone.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = root_bone.hpp; sourceTree = "<group>"; };
-		04F461AE26C4030D007CEEAB /* bone.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bone.hpp; sourceTree = "<group>"; };
-		04F461AF26C4030D007CEEAB /* skinnable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skinnable.hpp; sourceTree = "<group>"; };
-		04F461B026C4030D007CEEAB /* cubic_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_weight.hpp; sourceTree = "<group>"; };
-		04F461B126C4030D007CEEAB /* draw_rules.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_rules.hpp; sourceTree = "<group>"; };
-		04F461B226C4030D007CEEAB /* core.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core.hpp; sourceTree = "<group>"; };
-		04F461B326C4030D007CEEAB /* transform_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_component.hpp; sourceTree = "<group>"; };
+		04F4637126C510E0007CEEAB /* core_registry.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_registry.hpp; sourceTree = "<group>"; };
+		04F4637226C510E0007CEEAB /* node_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = node_base.hpp; sourceTree = "<group>"; };
+		04F4637326C510E0007CEEAB /* transform_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_component_base.hpp; sourceTree = "<group>"; };
+		04F4637526C510E0007CEEAB /* rotation_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = rotation_constraint_base.hpp; sourceTree = "<group>"; };
+		04F4637626C510E0007CEEAB /* constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = constraint_base.hpp; sourceTree = "<group>"; };
+		04F4637726C510E0007CEEAB /* targeted_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = targeted_constraint_base.hpp; sourceTree = "<group>"; };
+		04F4637826C510E0007CEEAB /* translation_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = translation_constraint_base.hpp; sourceTree = "<group>"; };
+		04F4637926C510E0007CEEAB /* scale_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = scale_constraint_base.hpp; sourceTree = "<group>"; };
+		04F4637A26C510E0007CEEAB /* ik_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ik_constraint_base.hpp; sourceTree = "<group>"; };
+		04F4637B26C510E0007CEEAB /* transform_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_constraint_base.hpp; sourceTree = "<group>"; };
+		04F4637C26C510E0007CEEAB /* transform_component_constraint_y_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_component_constraint_y_base.hpp; sourceTree = "<group>"; };
+		04F4637D26C510E0007CEEAB /* transform_space_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_space_constraint_base.hpp; sourceTree = "<group>"; };
+		04F4637E26C510E0007CEEAB /* distance_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = distance_constraint_base.hpp; sourceTree = "<group>"; };
+		04F4637F26C510E0007CEEAB /* transform_component_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_component_constraint_base.hpp; sourceTree = "<group>"; };
+		04F4638026C510E0007CEEAB /* artboard_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = artboard_base.hpp; sourceTree = "<group>"; };
+		04F4638126C510E0007CEEAB /* draw_rules_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_rules_base.hpp; sourceTree = "<group>"; };
+		04F4638226C510E0007CEEAB /* world_transform_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = world_transform_component_base.hpp; sourceTree = "<group>"; };
+		04F4638426C510E0007CEEAB /* blend_animation_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_base.hpp; sourceTree = "<group>"; };
+		04F4638526C510E0007CEEAB /* keyframe_bool_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_bool_base.hpp; sourceTree = "<group>"; };
+		04F4638626C510E0007CEEAB /* keyframe_color_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_color_base.hpp; sourceTree = "<group>"; };
+		04F4638726C510E0007CEEAB /* keyed_property_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_property_base.hpp; sourceTree = "<group>"; };
+		04F4638826C510E0007CEEAB /* keyframe_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_base.hpp; sourceTree = "<group>"; };
+		04F4638926C510E0007CEEAB /* animation_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_state_base.hpp; sourceTree = "<group>"; };
+		04F4638A26C510E0007CEEAB /* animation_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_base.hpp; sourceTree = "<group>"; };
+		04F4638B26C510E0007CEEAB /* blend_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_base.hpp; sourceTree = "<group>"; };
+		04F4638C26C510E0007CEEAB /* transition_number_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_number_condition_base.hpp; sourceTree = "<group>"; };
+		04F4638D26C510E0007CEEAB /* cubic_interpolator_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_interpolator_base.hpp; sourceTree = "<group>"; };
+		04F4638E26C510E0007CEEAB /* linear_animation_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_animation_base.hpp; sourceTree = "<group>"; };
+		04F4638F26C510E0007CEEAB /* entry_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = entry_state_base.hpp; sourceTree = "<group>"; };
+		04F4639026C510E0007CEEAB /* layer_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = layer_state_base.hpp; sourceTree = "<group>"; };
+		04F4639126C510E0007CEEAB /* state_machine_layer_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer_component_base.hpp; sourceTree = "<group>"; };
+		04F4639226C510E0007CEEAB /* blend_state_direct_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_direct_base.hpp; sourceTree = "<group>"; };
+		04F4639326C510E0007CEEAB /* state_machine_layer_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer_base.hpp; sourceTree = "<group>"; };
+		04F4639426C510E0007CEEAB /* keyframe_id_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_id_base.hpp; sourceTree = "<group>"; };
+		04F4639526C510E0007CEEAB /* blend_animation_1d_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_1d_base.hpp; sourceTree = "<group>"; };
+		04F4639626C510E0007CEEAB /* keyed_object_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_object_base.hpp; sourceTree = "<group>"; };
+		04F4639726C510E0007CEEAB /* transition_value_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_value_condition_base.hpp; sourceTree = "<group>"; };
+		04F4639826C510E0007CEEAB /* state_machine_number_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_number_base.hpp; sourceTree = "<group>"; };
+		04F4639926C510E0007CEEAB /* state_transition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_transition_base.hpp; sourceTree = "<group>"; };
+		04F4639A26C510E0007CEEAB /* keyframe_double_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_double_base.hpp; sourceTree = "<group>"; };
+		04F4639B26C510E0007CEEAB /* state_machine_bool_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_bool_base.hpp; sourceTree = "<group>"; };
+		04F4639C26C510E0007CEEAB /* blend_state_transition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_transition_base.hpp; sourceTree = "<group>"; };
+		04F4639D26C510E0007CEEAB /* blend_animation_direct_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_direct_base.hpp; sourceTree = "<group>"; };
+		04F4639E26C510E0007CEEAB /* transition_bool_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_bool_condition_base.hpp; sourceTree = "<group>"; };
+		04F4639F26C510E0007CEEAB /* transition_trigger_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_trigger_condition_base.hpp; sourceTree = "<group>"; };
+		04F463A026C510E0007CEEAB /* state_machine_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_component_base.hpp; sourceTree = "<group>"; };
+		04F463A126C510E0007CEEAB /* any_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = any_state_base.hpp; sourceTree = "<group>"; };
+		04F463A226C510E0007CEEAB /* transition_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_condition_base.hpp; sourceTree = "<group>"; };
+		04F463A326C510E0007CEEAB /* state_machine_input_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_input_base.hpp; sourceTree = "<group>"; };
+		04F463A426C510E0007CEEAB /* blend_state_1d_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_1d_base.hpp; sourceTree = "<group>"; };
+		04F463A526C510E0007CEEAB /* state_machine_trigger_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_trigger_base.hpp; sourceTree = "<group>"; };
+		04F463A626C510E0007CEEAB /* state_machine_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_base.hpp; sourceTree = "<group>"; };
+		04F463A726C510E0007CEEAB /* exit_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = exit_state_base.hpp; sourceTree = "<group>"; };
+		04F463AA26C510E0007CEEAB /* linear_gradient_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_gradient_base.hpp; sourceTree = "<group>"; };
+		04F463AB26C510E0007CEEAB /* stroke_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_base.hpp; sourceTree = "<group>"; };
+		04F463AC26C510E0007CEEAB /* fill_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fill_base.hpp; sourceTree = "<group>"; };
+		04F463AD26C510E0007CEEAB /* shape_paint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint_base.hpp; sourceTree = "<group>"; };
+		04F463AE26C510E0007CEEAB /* solid_color_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = solid_color_base.hpp; sourceTree = "<group>"; };
+		04F463AF26C510E0007CEEAB /* trim_path_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = trim_path_base.hpp; sourceTree = "<group>"; };
+		04F463B026C510E0007CEEAB /* radial_gradient_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = radial_gradient_base.hpp; sourceTree = "<group>"; };
+		04F463B126C510E0007CEEAB /* gradient_stop_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = gradient_stop_base.hpp; sourceTree = "<group>"; };
+		04F463B226C510E0007CEEAB /* parametric_path_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = parametric_path_base.hpp; sourceTree = "<group>"; };
+		04F463B326C510E0007CEEAB /* cubic_asymmetric_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_asymmetric_vertex_base.hpp; sourceTree = "<group>"; };
+		04F463B426C510E0007CEEAB /* cubic_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_vertex_base.hpp; sourceTree = "<group>"; };
+		04F463B526C510E0007CEEAB /* ellipse_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ellipse_base.hpp; sourceTree = "<group>"; };
+		04F463B626C510E0007CEEAB /* points_path_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = points_path_base.hpp; sourceTree = "<group>"; };
+		04F463B726C510E0007CEEAB /* triangle_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = triangle_base.hpp; sourceTree = "<group>"; };
+		04F463B826C510E0007CEEAB /* shape_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_base.hpp; sourceTree = "<group>"; };
+		04F463B926C510E0007CEEAB /* rectangle_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = rectangle_base.hpp; sourceTree = "<group>"; };
+		04F463BA26C510E0007CEEAB /* cubic_mirrored_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_mirrored_vertex_base.hpp; sourceTree = "<group>"; };
+		04F463BB26C510E0007CEEAB /* star_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = star_base.hpp; sourceTree = "<group>"; };
+		04F463BC26C510E0007CEEAB /* straight_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = straight_vertex_base.hpp; sourceTree = "<group>"; };
+		04F463BD26C510E0007CEEAB /* path_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_base.hpp; sourceTree = "<group>"; };
+		04F463BE26C510E0007CEEAB /* polygon_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = polygon_base.hpp; sourceTree = "<group>"; };
+		04F463BF26C510E0007CEEAB /* cubic_detached_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_detached_vertex_base.hpp; sourceTree = "<group>"; };
+		04F463C026C510E0007CEEAB /* clipping_shape_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = clipping_shape_base.hpp; sourceTree = "<group>"; };
+		04F463C126C510E0007CEEAB /* path_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_vertex_base.hpp; sourceTree = "<group>"; };
+		04F463C226C510E0007CEEAB /* container_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = container_component_base.hpp; sourceTree = "<group>"; };
+		04F463C326C510E0007CEEAB /* component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = component_base.hpp; sourceTree = "<group>"; };
+		04F463C526C510E0007CEEAB /* weight_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = weight_base.hpp; sourceTree = "<group>"; };
+		04F463C626C510E0007CEEAB /* root_bone_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = root_bone_base.hpp; sourceTree = "<group>"; };
+		04F463C726C510E0007CEEAB /* cubic_weight_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_weight_base.hpp; sourceTree = "<group>"; };
+		04F463C826C510E0007CEEAB /* bone_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bone_base.hpp; sourceTree = "<group>"; };
+		04F463C926C510E0007CEEAB /* skin_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skin_base.hpp; sourceTree = "<group>"; };
+		04F463CA26C510E0007CEEAB /* tendon_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = tendon_base.hpp; sourceTree = "<group>"; };
+		04F463CB26C510E0007CEEAB /* skeletal_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skeletal_component_base.hpp; sourceTree = "<group>"; };
+		04F463CC26C510E0007CEEAB /* draw_target_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_target_base.hpp; sourceTree = "<group>"; };
+		04F463CD26C510E0007CEEAB /* backboard_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = backboard_base.hpp; sourceTree = "<group>"; };
+		04F463CE26C510E0007CEEAB /* drawable_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = drawable_base.hpp; sourceTree = "<group>"; };
+		04F463CF26C510E0007CEEAB /* backboard.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = backboard.hpp; sourceTree = "<group>"; };
+		04F463D126C510E0007CEEAB /* reader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reader.h; sourceTree = "<group>"; };
+		04F463D326C510E0007CEEAB /* core_color_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_color_type.hpp; sourceTree = "<group>"; };
+		04F463D426C510E0007CEEAB /* core_uint_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_uint_type.hpp; sourceTree = "<group>"; };
+		04F463D526C510E0007CEEAB /* core_double_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_double_type.hpp; sourceTree = "<group>"; };
+		04F463D626C510E0007CEEAB /* core_string_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_string_type.hpp; sourceTree = "<group>"; };
+		04F463D726C510E0007CEEAB /* core_bool_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_bool_type.hpp; sourceTree = "<group>"; };
+		04F463D826C510E0007CEEAB /* binary_reader.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = binary_reader.hpp; sourceTree = "<group>"; };
+		04F463D926C510E0007CEEAB /* status_code.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = status_code.hpp; sourceTree = "<group>"; };
+		04F463DB26C510E0007CEEAB /* translation_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = translation_constraint.hpp; sourceTree = "<group>"; };
+		04F463DC26C510E0007CEEAB /* scale_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = scale_constraint.hpp; sourceTree = "<group>"; };
+		04F463DD26C510E0007CEEAB /* targeted_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = targeted_constraint.hpp; sourceTree = "<group>"; };
+		04F463DE26C510E0007CEEAB /* constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = constraint.hpp; sourceTree = "<group>"; };
+		04F463DF26C510E0007CEEAB /* rotation_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = rotation_constraint.hpp; sourceTree = "<group>"; };
+		04F463E026C510E0007CEEAB /* transform_component_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_component_constraint.hpp; sourceTree = "<group>"; };
+		04F463E126C510E0007CEEAB /* transform_space_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_space_constraint.hpp; sourceTree = "<group>"; };
+		04F463E226C510E0007CEEAB /* ik_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ik_constraint.hpp; sourceTree = "<group>"; };
+		04F463E326C510E0007CEEAB /* transform_component_constraint_y.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_component_constraint_y.hpp; sourceTree = "<group>"; };
+		04F463E426C510E0007CEEAB /* transform_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_constraint.hpp; sourceTree = "<group>"; };
+		04F463E526C510E0007CEEAB /* distance_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = distance_constraint.hpp; sourceTree = "<group>"; };
+		04F463E626C510E0007CEEAB /* component_dirt.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = component_dirt.hpp; sourceTree = "<group>"; };
+		04F463E726C510E0007CEEAB /* renderer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = renderer.hpp; sourceTree = "<group>"; };
+		04F463E826C510E0007CEEAB /* draw_target_placement.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_target_placement.hpp; sourceTree = "<group>"; };
+		04F463EA26C510E0007CEEAB /* state_transition_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_transition_importer.hpp; sourceTree = "<group>"; };
+		04F463EB26C510E0007CEEAB /* state_machine_layer_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer_importer.hpp; sourceTree = "<group>"; };
+		04F463EC26C510E0007CEEAB /* keyed_property_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_property_importer.hpp; sourceTree = "<group>"; };
+		04F463ED26C510E0007CEEAB /* keyed_object_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_object_importer.hpp; sourceTree = "<group>"; };
+		04F463EE26C510E0007CEEAB /* linear_animation_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_animation_importer.hpp; sourceTree = "<group>"; };
+		04F463EF26C510E0007CEEAB /* import_stack.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = import_stack.hpp; sourceTree = "<group>"; };
+		04F463F026C510E0007CEEAB /* layer_state_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = layer_state_importer.hpp; sourceTree = "<group>"; };
+		04F463F126C510E0007CEEAB /* artboard_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = artboard_importer.hpp; sourceTree = "<group>"; };
+		04F463F226C510E0007CEEAB /* state_machine_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_importer.hpp; sourceTree = "<group>"; };
+		04F463F326C510E0007CEEAB /* world_transform_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = world_transform_component.hpp; sourceTree = "<group>"; };
+		04F463F426C510E0007CEEAB /* draw_target.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_target.hpp; sourceTree = "<group>"; };
+		04F463F526C510E0007CEEAB /* runtime_header.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = runtime_header.hpp; sourceTree = "<group>"; };
+		04F463F626C510E0007CEEAB /* file.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = file.hpp; sourceTree = "<group>"; };
+		04F463F726C510E0007CEEAB /* container_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = container_component.hpp; sourceTree = "<group>"; };
+		04F463F926C510E0007CEEAB /* transition_bool_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_bool_condition.hpp; sourceTree = "<group>"; };
+		04F463FA26C510E0007CEEAB /* cubic_interpolator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_interpolator.hpp; sourceTree = "<group>"; };
+		04F463FB26C510E0007CEEAB /* keyed_property.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_property.hpp; sourceTree = "<group>"; };
+		04F463FC26C510E0007CEEAB /* state_machine_input.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_input.hpp; sourceTree = "<group>"; };
+		04F463FD26C510E0007CEEAB /* layer_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = layer_state.hpp; sourceTree = "<group>"; };
+		04F463FE26C510E0007CEEAB /* state_transition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_transition.hpp; sourceTree = "<group>"; };
+		04F463FF26C510E0007CEEAB /* system_state_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = system_state_instance.hpp; sourceTree = "<group>"; };
+		04F4640026C510E0007CEEAB /* state_machine_trigger.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_trigger.hpp; sourceTree = "<group>"; };
+		04F4640126C510E0007CEEAB /* keyframe_id.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_id.hpp; sourceTree = "<group>"; };
+		04F4640226C510E0007CEEAB /* blend_state_transition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_transition.hpp; sourceTree = "<group>"; };
+		04F4640326C510E0007CEEAB /* transition_number_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_number_condition.hpp; sourceTree = "<group>"; };
+		04F4640426C510E0007CEEAB /* state_machine_number.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_number.hpp; sourceTree = "<group>"; };
+		04F4640526C510E0007CEEAB /* animation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation.hpp; sourceTree = "<group>"; };
+		04F4640626C510E0007CEEAB /* keyframe.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe.hpp; sourceTree = "<group>"; };
+		04F4640726C510E0007CEEAB /* blend_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state.hpp; sourceTree = "<group>"; };
+		04F4640826C510E0007CEEAB /* state_machine_layer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer.hpp; sourceTree = "<group>"; };
+		04F4640926C510E0007CEEAB /* blend_animation_1d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_1d.hpp; sourceTree = "<group>"; };
+		04F4640A26C510E0007CEEAB /* state_machine_layer_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer_component.hpp; sourceTree = "<group>"; };
+		04F4640B26C510E0007CEEAB /* blend_state_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_instance.hpp; sourceTree = "<group>"; };
+		04F4640C26C510E0007CEEAB /* state_machine_bool.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_bool.hpp; sourceTree = "<group>"; };
+		04F4640D26C510E0007CEEAB /* blend_state_1d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_1d.hpp; sourceTree = "<group>"; };
+		04F4640E26C510E0007CEEAB /* state_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_instance.hpp; sourceTree = "<group>"; };
+		04F4640F26C510E0007CEEAB /* keyed_object.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_object.hpp; sourceTree = "<group>"; };
+		04F4641026C510E0007CEEAB /* state_machine_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_component.hpp; sourceTree = "<group>"; };
+		04F4641126C510E0007CEEAB /* state_machine.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine.hpp; sourceTree = "<group>"; };
+		04F4641226C510E0007CEEAB /* blend_state_1d_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_1d_instance.hpp; sourceTree = "<group>"; };
+		04F4641326C510E0007CEEAB /* keyframe_bool.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_bool.hpp; sourceTree = "<group>"; };
+		04F4641426C510E0007CEEAB /* state_machine_input_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_input_instance.hpp; sourceTree = "<group>"; };
+		04F4641526C510E0007CEEAB /* transition_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_condition.hpp; sourceTree = "<group>"; };
+		04F4641626C510E0007CEEAB /* transition_value_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_value_condition.hpp; sourceTree = "<group>"; };
+		04F4641726C510E0007CEEAB /* animation_state_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_state_instance.hpp; sourceTree = "<group>"; };
+		04F4641826C510E0007CEEAB /* linear_animation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_animation.hpp; sourceTree = "<group>"; };
+		04F4641926C510E0007CEEAB /* linear_animation_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_animation_instance.hpp; sourceTree = "<group>"; };
+		04F4641A26C510E0007CEEAB /* transition_condition_op.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_condition_op.hpp; sourceTree = "<group>"; };
+		04F4641B26C510E0007CEEAB /* blend_state_direct_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_direct_instance.hpp; sourceTree = "<group>"; };
+		04F4641C26C510E0007CEEAB /* keyframe_double.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_double.hpp; sourceTree = "<group>"; };
+		04F4641D26C510E0007CEEAB /* blend_animation_direct.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_direct.hpp; sourceTree = "<group>"; };
+		04F4641E26C510E0007CEEAB /* loop.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = loop.hpp; sourceTree = "<group>"; };
+		04F4641F26C510E0007CEEAB /* keyframe_color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_color.hpp; sourceTree = "<group>"; };
+		04F4642026C510E0007CEEAB /* entry_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = entry_state.hpp; sourceTree = "<group>"; };
+		04F4642126C510E0007CEEAB /* blend_animation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation.hpp; sourceTree = "<group>"; };
+		04F4642226C510E0007CEEAB /* state_machine_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_instance.hpp; sourceTree = "<group>"; };
+		04F4642326C510E0007CEEAB /* state_transition_flags.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_transition_flags.hpp; sourceTree = "<group>"; };
+		04F4642426C510E0007CEEAB /* exit_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = exit_state.hpp; sourceTree = "<group>"; };
+		04F4642526C510E0007CEEAB /* any_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = any_state.hpp; sourceTree = "<group>"; };
+		04F4642626C510E0007CEEAB /* animation_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_state.hpp; sourceTree = "<group>"; };
+		04F4642726C510E0007CEEAB /* blend_state_direct.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_direct.hpp; sourceTree = "<group>"; };
+		04F4642826C510E0007CEEAB /* transition_trigger_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_trigger_condition.hpp; sourceTree = "<group>"; };
+		04F4642926C510E0007CEEAB /* transform_space.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_space.hpp; sourceTree = "<group>"; };
+		04F4642B26C510E0007CEEAB /* straight_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = straight_vertex.hpp; sourceTree = "<group>"; };
+		04F4642D26C510E0007CEEAB /* stroke_cap.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_cap.hpp; sourceTree = "<group>"; };
+		04F4642E26C510E0007CEEAB /* gradient_stop.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = gradient_stop.hpp; sourceTree = "<group>"; };
+		04F4642F26C510E0007CEEAB /* stroke.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke.hpp; sourceTree = "<group>"; };
+		04F4643026C510E0007CEEAB /* shape_paint_mutator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint_mutator.hpp; sourceTree = "<group>"; };
+		04F4643126C510E0007CEEAB /* blend_mode.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_mode.hpp; sourceTree = "<group>"; };
+		04F4643226C510E0007CEEAB /* shape_paint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint.hpp; sourceTree = "<group>"; };
+		04F4643326C510E0007CEEAB /* stroke_join.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_join.hpp; sourceTree = "<group>"; };
+		04F4643426C510E0007CEEAB /* fill.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fill.hpp; sourceTree = "<group>"; };
+		04F4643526C510E0007CEEAB /* radial_gradient.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = radial_gradient.hpp; sourceTree = "<group>"; };
+		04F4643626C510E0007CEEAB /* trim_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = trim_path.hpp; sourceTree = "<group>"; };
+		04F4643726C510E0007CEEAB /* color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = color.hpp; sourceTree = "<group>"; };
+		04F4643826C510E0007CEEAB /* solid_color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = solid_color.hpp; sourceTree = "<group>"; };
+		04F4643926C510E0007CEEAB /* linear_gradient.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_gradient.hpp; sourceTree = "<group>"; };
+		04F4643A26C510E0007CEEAB /* stroke_effect.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_effect.hpp; sourceTree = "<group>"; };
+		04F4643B26C510E0007CEEAB /* path_composer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_composer.hpp; sourceTree = "<group>"; };
+		04F4643C26C510E0007CEEAB /* shape_paint_container.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint_container.hpp; sourceTree = "<group>"; };
+		04F4643D26C510E0007CEEAB /* cubic_mirrored_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_mirrored_vertex.hpp; sourceTree = "<group>"; };
+		04F4643E26C510E0007CEEAB /* path_space.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_space.hpp; sourceTree = "<group>"; };
+		04F4643F26C510E0007CEEAB /* ellipse.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ellipse.hpp; sourceTree = "<group>"; };
+		04F4644026C510E0007CEEAB /* clipping_shape.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = clipping_shape.hpp; sourceTree = "<group>"; };
+		04F4644126C510E0007CEEAB /* metrics_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = metrics_path.hpp; sourceTree = "<group>"; };
+		04F4644226C510E0007CEEAB /* cubic_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_vertex.hpp; sourceTree = "<group>"; };
+		04F4644326C510E0007CEEAB /* shape.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape.hpp; sourceTree = "<group>"; };
+		04F4644426C510E0007CEEAB /* triangle.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = triangle.hpp; sourceTree = "<group>"; };
+		04F4644526C510E0007CEEAB /* path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path.hpp; sourceTree = "<group>"; };
+		04F4644626C510E0007CEEAB /* polygon.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = polygon.hpp; sourceTree = "<group>"; };
+		04F4644726C510E0007CEEAB /* path_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_vertex.hpp; sourceTree = "<group>"; };
+		04F4644826C510E0007CEEAB /* parametric_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = parametric_path.hpp; sourceTree = "<group>"; };
+		04F4644926C510E0007CEEAB /* rectangle.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = rectangle.hpp; sourceTree = "<group>"; };
+		04F4644A26C510E0007CEEAB /* points_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = points_path.hpp; sourceTree = "<group>"; };
+		04F4644B26C510E0007CEEAB /* star.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = star.hpp; sourceTree = "<group>"; };
+		04F4644C26C510E0007CEEAB /* cubic_asymmetric_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_asymmetric_vertex.hpp; sourceTree = "<group>"; };
+		04F4644D26C510E0007CEEAB /* cubic_detached_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_detached_vertex.hpp; sourceTree = "<group>"; };
+		04F4644F26C510E0007CEEAB /* vec2d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = vec2d.hpp; sourceTree = "<group>"; };
+		04F4645026C510E0007CEEAB /* mat2d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = mat2d.hpp; sourceTree = "<group>"; };
+		04F4645126C510E0007CEEAB /* aabb.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = aabb.hpp; sourceTree = "<group>"; };
+		04F4645226C510E0007CEEAB /* color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = color.hpp; sourceTree = "<group>"; };
+		04F4645326C510E0007CEEAB /* transform_components.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_components.hpp; sourceTree = "<group>"; };
+		04F4645426C510E0007CEEAB /* circle_constant.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = circle_constant.hpp; sourceTree = "<group>"; };
+		04F4645526C510E0007CEEAB /* command_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = command_path.hpp; sourceTree = "<group>"; };
+		04F4645626C510E0007CEEAB /* component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = component.hpp; sourceTree = "<group>"; };
+		04F4645726C510E0007CEEAB /* node.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = node.hpp; sourceTree = "<group>"; };
+		04F4645826C510E0007CEEAB /* layout.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = layout.hpp; sourceTree = "<group>"; };
+		04F4645926C510E0007CEEAB /* drawable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = drawable.hpp; sourceTree = "<group>"; };
+		04F4645A26C510E0007CEEAB /* artboard.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = artboard.hpp; sourceTree = "<group>"; };
+		04F4645B26C510E0007CEEAB /* dependency_sorter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = dependency_sorter.hpp; sourceTree = "<group>"; };
+		04F4645C26C510E0007CEEAB /* core_context.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_context.hpp; sourceTree = "<group>"; };
+		04F4645E26C510E0007CEEAB /* tendon.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = tendon.hpp; sourceTree = "<group>"; };
+		04F4645F26C510E0007CEEAB /* skeletal_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skeletal_component.hpp; sourceTree = "<group>"; };
+		04F4646026C510E0007CEEAB /* weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = weight.hpp; sourceTree = "<group>"; };
+		04F4646126C510E0007CEEAB /* skin.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skin.hpp; sourceTree = "<group>"; };
+		04F4646226C510E0007CEEAB /* root_bone.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = root_bone.hpp; sourceTree = "<group>"; };
+		04F4646326C510E0007CEEAB /* bone.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bone.hpp; sourceTree = "<group>"; };
+		04F4646426C510E0007CEEAB /* skinnable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skinnable.hpp; sourceTree = "<group>"; };
+		04F4646526C510E0007CEEAB /* cubic_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_weight.hpp; sourceTree = "<group>"; };
+		04F4646626C510E0007CEEAB /* draw_rules.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_rules.hpp; sourceTree = "<group>"; };
+		04F4646726C510E0007CEEAB /* core.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core.hpp; sourceTree = "<group>"; };
+		04F4646826C510E0007CEEAB /* transform_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_component.hpp; sourceTree = "<group>"; };
+		04F4655326C51416007CEEAB /* translation_constraint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = translation_constraint.cpp; sourceTree = "<group>"; };
+		04F4655426C51416007CEEAB /* scale_constraint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scale_constraint.cpp; sourceTree = "<group>"; };
+		04F4655526C51416007CEEAB /* rotation_constraint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rotation_constraint.cpp; sourceTree = "<group>"; };
+		04F4655926C51422007CEEAB /* world_transform_component.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = world_transform_component.cpp; sourceTree = "<group>"; };
+		04F4655B26C514A3007CEEAB /* rotation_constraint_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rotation_constraint_base.cpp; sourceTree = "<group>"; };
+		04F4655C26C514A3007CEEAB /* translation_constraint_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = translation_constraint_base.cpp; sourceTree = "<group>"; };
+		04F4655D26C514A3007CEEAB /* scale_constraint_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scale_constraint_base.cpp; sourceTree = "<group>"; };
+		04F4656126C514AC007CEEAB /* keyframe_bool_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = keyframe_bool_base.cpp; sourceTree = "<group>"; };
+		04F4656326C514B7007CEEAB /* keyframe_bool.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = keyframe_bool.cpp; sourceTree = "<group>"; };
 		C9002A1F263C76080011556B /* RiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RiveView.swift; sourceTree = "<group>"; };
 		C9601F29250C25830032AA07 /* RiveRenderer.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RiveRenderer.hpp; sourceTree = "<group>"; };
 		C9601F2A250C25930032AA07 /* RiveRenderer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RiveRenderer.mm; sourceTree = "<group>"; };
@@ -960,6 +1010,9 @@
 		04F1C92026A84B5200CEE6BE /* constraints */ = {
 			isa = PBXGroup;
 			children = (
+				04F4655526C51416007CEEAB /* rotation_constraint.cpp */,
+				04F4655426C51416007CEEAB /* scale_constraint.cpp */,
+				04F4655326C51416007CEEAB /* translation_constraint.cpp */,
 				0450446C26B3F82D007B25CA /* distance_constraint.cpp */,
 				0450446D26B3F82D007B25CA /* transform_constraint.cpp */,
 				04F1C92126A84B5200CEE6BE /* constraint.cpp */,
@@ -972,6 +1025,9 @@
 		04F1C92726A84B7B00CEE6BE /* constraints */ = {
 			isa = PBXGroup;
 			children = (
+				04F4655B26C514A3007CEEAB /* rotation_constraint_base.cpp */,
+				04F4655D26C514A3007CEEAB /* scale_constraint_base.cpp */,
+				04F4655C26C514A3007CEEAB /* translation_constraint_base.cpp */,
 				0450447026B3F83C007B25CA /* distance_constraint_base.cpp */,
 				0450447126B3F83C007B25CA /* transform_constraint_base.cpp */,
 				04F1C92826A84B7B00CEE6BE /* ik_constraint_base.cpp */,
@@ -979,356 +1035,372 @@
 			path = constraints;
 			sourceTree = "<group>";
 		};
-		04F460A726C401B9007CEEAB /* include */ = {
+		04F4636E26C510E0007CEEAB /* include */ = {
 			isa = PBXGroup;
 			children = (
-				04F460CA26C4030C007CEEAB /* rive */,
+				04F4636F26C510E0007CEEAB /* rive */,
 			);
 			name = include;
+			path = "submodules/rive-cpp/include";
 			sourceTree = "<group>";
 		};
-		04F460CA26C4030C007CEEAB /* rive */ = {
+		04F4636F26C510E0007CEEAB /* rive */ = {
 			isa = PBXGroup;
 			children = (
-				04F460CB26C4030C007CEEAB /* generated */,
-				04F4612226C4030D007CEEAB /* backboard.hpp */,
-				04F4612326C4030D007CEEAB /* core */,
-				04F4612C26C4030D007CEEAB /* status_code.hpp */,
-				04F4612D26C4030D007CEEAB /* constraints */,
-				04F4613326C4030D007CEEAB /* component_dirt.hpp */,
-				04F4613426C4030D007CEEAB /* renderer.hpp */,
-				04F4613526C4030D007CEEAB /* draw_target_placement.hpp */,
-				04F4613626C4030D007CEEAB /* importers */,
-				04F4614026C4030D007CEEAB /* draw_target.hpp */,
-				04F4614126C4030D007CEEAB /* runtime_header.hpp */,
-				04F4614226C4030D007CEEAB /* file.hpp */,
-				04F4614326C4030D007CEEAB /* container_component.hpp */,
-				04F4614426C4030D007CEEAB /* animation */,
-				04F4617426C4030D007CEEAB /* transform_space.hpp */,
-				04F4617526C4030D007CEEAB /* shapes */,
-				04F4619926C4030D007CEEAB /* math */,
-				04F461A026C4030D007CEEAB /* command_path.hpp */,
-				04F461A126C4030D007CEEAB /* component.hpp */,
-				04F461A226C4030D007CEEAB /* node.hpp */,
-				04F461A326C4030D007CEEAB /* layout.hpp */,
-				04F461A426C4030D007CEEAB /* drawable.hpp */,
-				04F461A526C4030D007CEEAB /* artboard.hpp */,
-				04F461A626C4030D007CEEAB /* dependency_sorter.hpp */,
-				04F461A726C4030D007CEEAB /* core_context.hpp */,
-				04F461A826C4030D007CEEAB /* bones */,
-				04F461B126C4030D007CEEAB /* draw_rules.hpp */,
-				04F461B226C4030D007CEEAB /* core.hpp */,
-				04F461B326C4030D007CEEAB /* transform_component.hpp */,
+				04F4637026C510E0007CEEAB /* generated */,
+				04F463CF26C510E0007CEEAB /* backboard.hpp */,
+				04F463D026C510E0007CEEAB /* core */,
+				04F463D926C510E0007CEEAB /* status_code.hpp */,
+				04F463DA26C510E0007CEEAB /* constraints */,
+				04F463E626C510E0007CEEAB /* component_dirt.hpp */,
+				04F463E726C510E0007CEEAB /* renderer.hpp */,
+				04F463E826C510E0007CEEAB /* draw_target_placement.hpp */,
+				04F463E926C510E0007CEEAB /* importers */,
+				04F463F326C510E0007CEEAB /* world_transform_component.hpp */,
+				04F463F426C510E0007CEEAB /* draw_target.hpp */,
+				04F463F526C510E0007CEEAB /* runtime_header.hpp */,
+				04F463F626C510E0007CEEAB /* file.hpp */,
+				04F463F726C510E0007CEEAB /* container_component.hpp */,
+				04F463F826C510E0007CEEAB /* animation */,
+				04F4642926C510E0007CEEAB /* transform_space.hpp */,
+				04F4642A26C510E0007CEEAB /* shapes */,
+				04F4644E26C510E0007CEEAB /* math */,
+				04F4645526C510E0007CEEAB /* command_path.hpp */,
+				04F4645626C510E0007CEEAB /* component.hpp */,
+				04F4645726C510E0007CEEAB /* node.hpp */,
+				04F4645826C510E0007CEEAB /* layout.hpp */,
+				04F4645926C510E0007CEEAB /* drawable.hpp */,
+				04F4645A26C510E0007CEEAB /* artboard.hpp */,
+				04F4645B26C510E0007CEEAB /* dependency_sorter.hpp */,
+				04F4645C26C510E0007CEEAB /* core_context.hpp */,
+				04F4645D26C510E0007CEEAB /* bones */,
+				04F4646626C510E0007CEEAB /* draw_rules.hpp */,
+				04F4646726C510E0007CEEAB /* core.hpp */,
+				04F4646826C510E0007CEEAB /* transform_component.hpp */,
 			);
-			name = rive;
-			path = "submodules/rive-cpp/include/rive";
+			path = rive;
 			sourceTree = "<group>";
 		};
-		04F460CB26C4030C007CEEAB /* generated */ = {
+		04F4637026C510E0007CEEAB /* generated */ = {
 			isa = PBXGroup;
 			children = (
-				04F460CC26C4030C007CEEAB /* core_registry.hpp */,
-				04F460CD26C4030C007CEEAB /* node_base.hpp */,
-				04F460CE26C4030C007CEEAB /* transform_component_base.hpp */,
-				04F460CF26C4030C007CEEAB /* constraints */,
-				04F460D526C4030C007CEEAB /* artboard_base.hpp */,
-				04F460D626C4030C007CEEAB /* draw_rules_base.hpp */,
-				04F460D726C4030C007CEEAB /* animation */,
-				04F460FB26C4030D007CEEAB /* shapes */,
-				04F4611526C4030D007CEEAB /* container_component_base.hpp */,
-				04F4611626C4030D007CEEAB /* component_base.hpp */,
-				04F4611726C4030D007CEEAB /* bones */,
-				04F4611F26C4030D007CEEAB /* draw_target_base.hpp */,
-				04F4612026C4030D007CEEAB /* backboard_base.hpp */,
-				04F4612126C4030D007CEEAB /* drawable_base.hpp */,
+				04F4637126C510E0007CEEAB /* core_registry.hpp */,
+				04F4637226C510E0007CEEAB /* node_base.hpp */,
+				04F4637326C510E0007CEEAB /* transform_component_base.hpp */,
+				04F4637426C510E0007CEEAB /* constraints */,
+				04F4638026C510E0007CEEAB /* artboard_base.hpp */,
+				04F4638126C510E0007CEEAB /* draw_rules_base.hpp */,
+				04F4638226C510E0007CEEAB /* world_transform_component_base.hpp */,
+				04F4638326C510E0007CEEAB /* animation */,
+				04F463A826C510E0007CEEAB /* shapes */,
+				04F463C226C510E0007CEEAB /* container_component_base.hpp */,
+				04F463C326C510E0007CEEAB /* component_base.hpp */,
+				04F463C426C510E0007CEEAB /* bones */,
+				04F463CC26C510E0007CEEAB /* draw_target_base.hpp */,
+				04F463CD26C510E0007CEEAB /* backboard_base.hpp */,
+				04F463CE26C510E0007CEEAB /* drawable_base.hpp */,
 			);
 			path = generated;
 			sourceTree = "<group>";
 		};
-		04F460CF26C4030C007CEEAB /* constraints */ = {
+		04F4637426C510E0007CEEAB /* constraints */ = {
 			isa = PBXGroup;
 			children = (
-				04F460D026C4030C007CEEAB /* constraint_base.hpp */,
-				04F460D126C4030C007CEEAB /* targeted_constraint_base.hpp */,
-				04F460D226C4030C007CEEAB /* ik_constraint_base.hpp */,
-				04F460D326C4030C007CEEAB /* transform_constraint_base.hpp */,
-				04F460D426C4030C007CEEAB /* distance_constraint_base.hpp */,
+				04F4637526C510E0007CEEAB /* rotation_constraint_base.hpp */,
+				04F4637626C510E0007CEEAB /* constraint_base.hpp */,
+				04F4637726C510E0007CEEAB /* targeted_constraint_base.hpp */,
+				04F4637826C510E0007CEEAB /* translation_constraint_base.hpp */,
+				04F4637926C510E0007CEEAB /* scale_constraint_base.hpp */,
+				04F4637A26C510E0007CEEAB /* ik_constraint_base.hpp */,
+				04F4637B26C510E0007CEEAB /* transform_constraint_base.hpp */,
+				04F4637C26C510E0007CEEAB /* transform_component_constraint_y_base.hpp */,
+				04F4637D26C510E0007CEEAB /* transform_space_constraint_base.hpp */,
+				04F4637E26C510E0007CEEAB /* distance_constraint_base.hpp */,
+				04F4637F26C510E0007CEEAB /* transform_component_constraint_base.hpp */,
 			);
 			path = constraints;
 			sourceTree = "<group>";
 		};
-		04F460D726C4030C007CEEAB /* animation */ = {
+		04F4638326C510E0007CEEAB /* animation */ = {
 			isa = PBXGroup;
 			children = (
-				04F460D826C4030C007CEEAB /* blend_animation_base.hpp */,
-				04F460D926C4030C007CEEAB /* keyframe_color_base.hpp */,
-				04F460DA26C4030C007CEEAB /* keyed_property_base.hpp */,
-				04F460DB26C4030C007CEEAB /* keyframe_base.hpp */,
-				04F460DC26C4030C007CEEAB /* animation_state_base.hpp */,
-				04F460DD26C4030C007CEEAB /* animation_base.hpp */,
-				04F460DE26C4030C007CEEAB /* blend_state_base.hpp */,
-				04F460DF26C4030C007CEEAB /* transition_number_condition_base.hpp */,
-				04F460E026C4030C007CEEAB /* cubic_interpolator_base.hpp */,
-				04F460E126C4030C007CEEAB /* linear_animation_base.hpp */,
-				04F460E226C4030C007CEEAB /* entry_state_base.hpp */,
-				04F460E326C4030C007CEEAB /* layer_state_base.hpp */,
-				04F460E426C4030C007CEEAB /* state_machine_layer_component_base.hpp */,
-				04F460E526C4030C007CEEAB /* blend_state_direct_base.hpp */,
-				04F460E626C4030C007CEEAB /* state_machine_layer_base.hpp */,
-				04F460E726C4030C007CEEAB /* keyframe_id_base.hpp */,
-				04F460E826C4030C007CEEAB /* blend_animation_1d_base.hpp */,
-				04F460E926C4030C007CEEAB /* keyed_object_base.hpp */,
-				04F460EA26C4030C007CEEAB /* transition_value_condition_base.hpp */,
-				04F460EB26C4030C007CEEAB /* state_machine_number_base.hpp */,
-				04F460EC26C4030C007CEEAB /* state_transition_base.hpp */,
-				04F460ED26C4030C007CEEAB /* keyframe_double_base.hpp */,
-				04F460EE26C4030C007CEEAB /* state_machine_bool_base.hpp */,
-				04F460EF26C4030C007CEEAB /* blend_state_transition_base.hpp */,
-				04F460F026C4030C007CEEAB /* blend_animation_direct_base.hpp */,
-				04F460F126C4030C007CEEAB /* transition_bool_condition_base.hpp */,
-				04F460F226C4030C007CEEAB /* transition_trigger_condition_base.hpp */,
-				04F460F326C4030C007CEEAB /* state_machine_component_base.hpp */,
-				04F460F426C4030C007CEEAB /* any_state_base.hpp */,
-				04F460F526C4030C007CEEAB /* transition_condition_base.hpp */,
-				04F460F626C4030C007CEEAB /* state_machine_input_base.hpp */,
-				04F460F726C4030D007CEEAB /* blend_state_1d_base.hpp */,
-				04F460F826C4030D007CEEAB /* state_machine_trigger_base.hpp */,
-				04F460F926C4030D007CEEAB /* state_machine_base.hpp */,
-				04F460FA26C4030D007CEEAB /* exit_state_base.hpp */,
+				04F4638426C510E0007CEEAB /* blend_animation_base.hpp */,
+				04F4638526C510E0007CEEAB /* keyframe_bool_base.hpp */,
+				04F4638626C510E0007CEEAB /* keyframe_color_base.hpp */,
+				04F4638726C510E0007CEEAB /* keyed_property_base.hpp */,
+				04F4638826C510E0007CEEAB /* keyframe_base.hpp */,
+				04F4638926C510E0007CEEAB /* animation_state_base.hpp */,
+				04F4638A26C510E0007CEEAB /* animation_base.hpp */,
+				04F4638B26C510E0007CEEAB /* blend_state_base.hpp */,
+				04F4638C26C510E0007CEEAB /* transition_number_condition_base.hpp */,
+				04F4638D26C510E0007CEEAB /* cubic_interpolator_base.hpp */,
+				04F4638E26C510E0007CEEAB /* linear_animation_base.hpp */,
+				04F4638F26C510E0007CEEAB /* entry_state_base.hpp */,
+				04F4639026C510E0007CEEAB /* layer_state_base.hpp */,
+				04F4639126C510E0007CEEAB /* state_machine_layer_component_base.hpp */,
+				04F4639226C510E0007CEEAB /* blend_state_direct_base.hpp */,
+				04F4639326C510E0007CEEAB /* state_machine_layer_base.hpp */,
+				04F4639426C510E0007CEEAB /* keyframe_id_base.hpp */,
+				04F4639526C510E0007CEEAB /* blend_animation_1d_base.hpp */,
+				04F4639626C510E0007CEEAB /* keyed_object_base.hpp */,
+				04F4639726C510E0007CEEAB /* transition_value_condition_base.hpp */,
+				04F4639826C510E0007CEEAB /* state_machine_number_base.hpp */,
+				04F4639926C510E0007CEEAB /* state_transition_base.hpp */,
+				04F4639A26C510E0007CEEAB /* keyframe_double_base.hpp */,
+				04F4639B26C510E0007CEEAB /* state_machine_bool_base.hpp */,
+				04F4639C26C510E0007CEEAB /* blend_state_transition_base.hpp */,
+				04F4639D26C510E0007CEEAB /* blend_animation_direct_base.hpp */,
+				04F4639E26C510E0007CEEAB /* transition_bool_condition_base.hpp */,
+				04F4639F26C510E0007CEEAB /* transition_trigger_condition_base.hpp */,
+				04F463A026C510E0007CEEAB /* state_machine_component_base.hpp */,
+				04F463A126C510E0007CEEAB /* any_state_base.hpp */,
+				04F463A226C510E0007CEEAB /* transition_condition_base.hpp */,
+				04F463A326C510E0007CEEAB /* state_machine_input_base.hpp */,
+				04F463A426C510E0007CEEAB /* blend_state_1d_base.hpp */,
+				04F463A526C510E0007CEEAB /* state_machine_trigger_base.hpp */,
+				04F463A626C510E0007CEEAB /* state_machine_base.hpp */,
+				04F463A726C510E0007CEEAB /* exit_state_base.hpp */,
 			);
 			path = animation;
 			sourceTree = "<group>";
 		};
-		04F460FB26C4030D007CEEAB /* shapes */ = {
+		04F463A826C510E0007CEEAB /* shapes */ = {
 			isa = PBXGroup;
 			children = (
-				04F460FC26C4030D007CEEAB /* paint */,
-				04F4610526C4030D007CEEAB /* parametric_path_base.hpp */,
-				04F4610626C4030D007CEEAB /* cubic_asymmetric_vertex_base.hpp */,
-				04F4610726C4030D007CEEAB /* cubic_vertex_base.hpp */,
-				04F4610826C4030D007CEEAB /* ellipse_base.hpp */,
-				04F4610926C4030D007CEEAB /* points_path_base.hpp */,
-				04F4610A26C4030D007CEEAB /* triangle_base.hpp */,
-				04F4610B26C4030D007CEEAB /* shape_base.hpp */,
-				04F4610C26C4030D007CEEAB /* rectangle_base.hpp */,
-				04F4610D26C4030D007CEEAB /* cubic_mirrored_vertex_base.hpp */,
-				04F4610E26C4030D007CEEAB /* star_base.hpp */,
-				04F4610F26C4030D007CEEAB /* straight_vertex_base.hpp */,
-				04F4611026C4030D007CEEAB /* path_base.hpp */,
-				04F4611126C4030D007CEEAB /* polygon_base.hpp */,
-				04F4611226C4030D007CEEAB /* cubic_detached_vertex_base.hpp */,
-				04F4611326C4030D007CEEAB /* clipping_shape_base.hpp */,
-				04F4611426C4030D007CEEAB /* path_vertex_base.hpp */,
+				04F463A926C510E0007CEEAB /* paint */,
+				04F463B226C510E0007CEEAB /* parametric_path_base.hpp */,
+				04F463B326C510E0007CEEAB /* cubic_asymmetric_vertex_base.hpp */,
+				04F463B426C510E0007CEEAB /* cubic_vertex_base.hpp */,
+				04F463B526C510E0007CEEAB /* ellipse_base.hpp */,
+				04F463B626C510E0007CEEAB /* points_path_base.hpp */,
+				04F463B726C510E0007CEEAB /* triangle_base.hpp */,
+				04F463B826C510E0007CEEAB /* shape_base.hpp */,
+				04F463B926C510E0007CEEAB /* rectangle_base.hpp */,
+				04F463BA26C510E0007CEEAB /* cubic_mirrored_vertex_base.hpp */,
+				04F463BB26C510E0007CEEAB /* star_base.hpp */,
+				04F463BC26C510E0007CEEAB /* straight_vertex_base.hpp */,
+				04F463BD26C510E0007CEEAB /* path_base.hpp */,
+				04F463BE26C510E0007CEEAB /* polygon_base.hpp */,
+				04F463BF26C510E0007CEEAB /* cubic_detached_vertex_base.hpp */,
+				04F463C026C510E0007CEEAB /* clipping_shape_base.hpp */,
+				04F463C126C510E0007CEEAB /* path_vertex_base.hpp */,
 			);
 			path = shapes;
 			sourceTree = "<group>";
 		};
-		04F460FC26C4030D007CEEAB /* paint */ = {
+		04F463A926C510E0007CEEAB /* paint */ = {
 			isa = PBXGroup;
 			children = (
-				04F460FD26C4030D007CEEAB /* linear_gradient_base.hpp */,
-				04F460FE26C4030D007CEEAB /* stroke_base.hpp */,
-				04F460FF26C4030D007CEEAB /* fill_base.hpp */,
-				04F4610026C4030D007CEEAB /* shape_paint_base.hpp */,
-				04F4610126C4030D007CEEAB /* solid_color_base.hpp */,
-				04F4610226C4030D007CEEAB /* trim_path_base.hpp */,
-				04F4610326C4030D007CEEAB /* radial_gradient_base.hpp */,
-				04F4610426C4030D007CEEAB /* gradient_stop_base.hpp */,
+				04F463AA26C510E0007CEEAB /* linear_gradient_base.hpp */,
+				04F463AB26C510E0007CEEAB /* stroke_base.hpp */,
+				04F463AC26C510E0007CEEAB /* fill_base.hpp */,
+				04F463AD26C510E0007CEEAB /* shape_paint_base.hpp */,
+				04F463AE26C510E0007CEEAB /* solid_color_base.hpp */,
+				04F463AF26C510E0007CEEAB /* trim_path_base.hpp */,
+				04F463B026C510E0007CEEAB /* radial_gradient_base.hpp */,
+				04F463B126C510E0007CEEAB /* gradient_stop_base.hpp */,
 			);
 			path = paint;
 			sourceTree = "<group>";
 		};
-		04F4611726C4030D007CEEAB /* bones */ = {
+		04F463C426C510E0007CEEAB /* bones */ = {
 			isa = PBXGroup;
 			children = (
-				04F4611826C4030D007CEEAB /* weight_base.hpp */,
-				04F4611926C4030D007CEEAB /* root_bone_base.hpp */,
-				04F4611A26C4030D007CEEAB /* cubic_weight_base.hpp */,
-				04F4611B26C4030D007CEEAB /* bone_base.hpp */,
-				04F4611C26C4030D007CEEAB /* skin_base.hpp */,
-				04F4611D26C4030D007CEEAB /* tendon_base.hpp */,
-				04F4611E26C4030D007CEEAB /* skeletal_component_base.hpp */,
+				04F463C526C510E0007CEEAB /* weight_base.hpp */,
+				04F463C626C510E0007CEEAB /* root_bone_base.hpp */,
+				04F463C726C510E0007CEEAB /* cubic_weight_base.hpp */,
+				04F463C826C510E0007CEEAB /* bone_base.hpp */,
+				04F463C926C510E0007CEEAB /* skin_base.hpp */,
+				04F463CA26C510E0007CEEAB /* tendon_base.hpp */,
+				04F463CB26C510E0007CEEAB /* skeletal_component_base.hpp */,
 			);
 			path = bones;
 			sourceTree = "<group>";
 		};
-		04F4612326C4030D007CEEAB /* core */ = {
+		04F463D026C510E0007CEEAB /* core */ = {
 			isa = PBXGroup;
 			children = (
-				04F4612426C4030D007CEEAB /* reader.h */,
-				04F4612526C4030D007CEEAB /* field_types */,
-				04F4612B26C4030D007CEEAB /* binary_reader.hpp */,
+				04F463D126C510E0007CEEAB /* reader.h */,
+				04F463D226C510E0007CEEAB /* field_types */,
+				04F463D826C510E0007CEEAB /* binary_reader.hpp */,
 			);
 			path = core;
 			sourceTree = "<group>";
 		};
-		04F4612526C4030D007CEEAB /* field_types */ = {
+		04F463D226C510E0007CEEAB /* field_types */ = {
 			isa = PBXGroup;
 			children = (
-				04F4612626C4030D007CEEAB /* core_color_type.hpp */,
-				04F4612726C4030D007CEEAB /* core_uint_type.hpp */,
-				04F4612826C4030D007CEEAB /* core_double_type.hpp */,
-				04F4612926C4030D007CEEAB /* core_string_type.hpp */,
-				04F4612A26C4030D007CEEAB /* core_bool_type.hpp */,
+				04F463D326C510E0007CEEAB /* core_color_type.hpp */,
+				04F463D426C510E0007CEEAB /* core_uint_type.hpp */,
+				04F463D526C510E0007CEEAB /* core_double_type.hpp */,
+				04F463D626C510E0007CEEAB /* core_string_type.hpp */,
+				04F463D726C510E0007CEEAB /* core_bool_type.hpp */,
 			);
 			path = field_types;
 			sourceTree = "<group>";
 		};
-		04F4612D26C4030D007CEEAB /* constraints */ = {
+		04F463DA26C510E0007CEEAB /* constraints */ = {
 			isa = PBXGroup;
 			children = (
-				04F4612E26C4030D007CEEAB /* targeted_constraint.hpp */,
-				04F4612F26C4030D007CEEAB /* constraint.hpp */,
-				04F4613026C4030D007CEEAB /* ik_constraint.hpp */,
-				04F4613126C4030D007CEEAB /* transform_constraint.hpp */,
-				04F4613226C4030D007CEEAB /* distance_constraint.hpp */,
+				04F463DB26C510E0007CEEAB /* translation_constraint.hpp */,
+				04F463DC26C510E0007CEEAB /* scale_constraint.hpp */,
+				04F463DD26C510E0007CEEAB /* targeted_constraint.hpp */,
+				04F463DE26C510E0007CEEAB /* constraint.hpp */,
+				04F463DF26C510E0007CEEAB /* rotation_constraint.hpp */,
+				04F463E026C510E0007CEEAB /* transform_component_constraint.hpp */,
+				04F463E126C510E0007CEEAB /* transform_space_constraint.hpp */,
+				04F463E226C510E0007CEEAB /* ik_constraint.hpp */,
+				04F463E326C510E0007CEEAB /* transform_component_constraint_y.hpp */,
+				04F463E426C510E0007CEEAB /* transform_constraint.hpp */,
+				04F463E526C510E0007CEEAB /* distance_constraint.hpp */,
 			);
 			path = constraints;
 			sourceTree = "<group>";
 		};
-		04F4613626C4030D007CEEAB /* importers */ = {
+		04F463E926C510E0007CEEAB /* importers */ = {
 			isa = PBXGroup;
 			children = (
-				04F4613726C4030D007CEEAB /* state_transition_importer.hpp */,
-				04F4613826C4030D007CEEAB /* state_machine_layer_importer.hpp */,
-				04F4613926C4030D007CEEAB /* keyed_property_importer.hpp */,
-				04F4613A26C4030D007CEEAB /* keyed_object_importer.hpp */,
-				04F4613B26C4030D007CEEAB /* linear_animation_importer.hpp */,
-				04F4613C26C4030D007CEEAB /* import_stack.hpp */,
-				04F4613D26C4030D007CEEAB /* layer_state_importer.hpp */,
-				04F4613E26C4030D007CEEAB /* artboard_importer.hpp */,
-				04F4613F26C4030D007CEEAB /* state_machine_importer.hpp */,
+				04F463EA26C510E0007CEEAB /* state_transition_importer.hpp */,
+				04F463EB26C510E0007CEEAB /* state_machine_layer_importer.hpp */,
+				04F463EC26C510E0007CEEAB /* keyed_property_importer.hpp */,
+				04F463ED26C510E0007CEEAB /* keyed_object_importer.hpp */,
+				04F463EE26C510E0007CEEAB /* linear_animation_importer.hpp */,
+				04F463EF26C510E0007CEEAB /* import_stack.hpp */,
+				04F463F026C510E0007CEEAB /* layer_state_importer.hpp */,
+				04F463F126C510E0007CEEAB /* artboard_importer.hpp */,
+				04F463F226C510E0007CEEAB /* state_machine_importer.hpp */,
 			);
 			path = importers;
 			sourceTree = "<group>";
 		};
-		04F4614426C4030D007CEEAB /* animation */ = {
+		04F463F826C510E0007CEEAB /* animation */ = {
 			isa = PBXGroup;
 			children = (
-				04F4614526C4030D007CEEAB /* transition_bool_condition.hpp */,
-				04F4614626C4030D007CEEAB /* cubic_interpolator.hpp */,
-				04F4614726C4030D007CEEAB /* keyed_property.hpp */,
-				04F4614826C4030D007CEEAB /* state_machine_input.hpp */,
-				04F4614926C4030D007CEEAB /* layer_state.hpp */,
-				04F4614A26C4030D007CEEAB /* state_transition.hpp */,
-				04F4614B26C4030D007CEEAB /* system_state_instance.hpp */,
-				04F4614C26C4030D007CEEAB /* state_machine_trigger.hpp */,
-				04F4614D26C4030D007CEEAB /* keyframe_id.hpp */,
-				04F4614E26C4030D007CEEAB /* blend_state_transition.hpp */,
-				04F4614F26C4030D007CEEAB /* transition_number_condition.hpp */,
-				04F4615026C4030D007CEEAB /* state_machine_number.hpp */,
-				04F4615126C4030D007CEEAB /* animation.hpp */,
-				04F4615226C4030D007CEEAB /* keyframe.hpp */,
-				04F4615326C4030D007CEEAB /* blend_state.hpp */,
-				04F4615426C4030D007CEEAB /* state_machine_layer.hpp */,
-				04F4615526C4030D007CEEAB /* blend_animation_1d.hpp */,
-				04F4615626C4030D007CEEAB /* state_machine_layer_component.hpp */,
-				04F4615726C4030D007CEEAB /* blend_state_instance.hpp */,
-				04F4615826C4030D007CEEAB /* state_machine_bool.hpp */,
-				04F4615926C4030D007CEEAB /* blend_state_1d.hpp */,
-				04F4615A26C4030D007CEEAB /* state_instance.hpp */,
-				04F4615B26C4030D007CEEAB /* keyed_object.hpp */,
-				04F4615C26C4030D007CEEAB /* state_machine_component.hpp */,
-				04F4615D26C4030D007CEEAB /* state_machine.hpp */,
-				04F4615E26C4030D007CEEAB /* blend_state_1d_instance.hpp */,
-				04F4615F26C4030D007CEEAB /* state_machine_input_instance.hpp */,
-				04F4616026C4030D007CEEAB /* transition_condition.hpp */,
-				04F4616126C4030D007CEEAB /* transition_value_condition.hpp */,
-				04F4616226C4030D007CEEAB /* animation_state_instance.hpp */,
-				04F4616326C4030D007CEEAB /* linear_animation.hpp */,
-				04F4616426C4030D007CEEAB /* linear_animation_instance.hpp */,
-				04F4616526C4030D007CEEAB /* transition_condition_op.hpp */,
-				04F4616626C4030D007CEEAB /* blend_state_direct_instance.hpp */,
-				04F4616726C4030D007CEEAB /* keyframe_double.hpp */,
-				04F4616826C4030D007CEEAB /* blend_animation_direct.hpp */,
-				04F4616926C4030D007CEEAB /* loop.hpp */,
-				04F4616A26C4030D007CEEAB /* keyframe_color.hpp */,
-				04F4616B26C4030D007CEEAB /* entry_state.hpp */,
-				04F4616C26C4030D007CEEAB /* blend_animation.hpp */,
-				04F4616D26C4030D007CEEAB /* state_machine_instance.hpp */,
-				04F4616E26C4030D007CEEAB /* state_transition_flags.hpp */,
-				04F4616F26C4030D007CEEAB /* exit_state.hpp */,
-				04F4617026C4030D007CEEAB /* any_state.hpp */,
-				04F4617126C4030D007CEEAB /* animation_state.hpp */,
-				04F4617226C4030D007CEEAB /* blend_state_direct.hpp */,
-				04F4617326C4030D007CEEAB /* transition_trigger_condition.hpp */,
+				04F463F926C510E0007CEEAB /* transition_bool_condition.hpp */,
+				04F463FA26C510E0007CEEAB /* cubic_interpolator.hpp */,
+				04F463FB26C510E0007CEEAB /* keyed_property.hpp */,
+				04F463FC26C510E0007CEEAB /* state_machine_input.hpp */,
+				04F463FD26C510E0007CEEAB /* layer_state.hpp */,
+				04F463FE26C510E0007CEEAB /* state_transition.hpp */,
+				04F463FF26C510E0007CEEAB /* system_state_instance.hpp */,
+				04F4640026C510E0007CEEAB /* state_machine_trigger.hpp */,
+				04F4640126C510E0007CEEAB /* keyframe_id.hpp */,
+				04F4640226C510E0007CEEAB /* blend_state_transition.hpp */,
+				04F4640326C510E0007CEEAB /* transition_number_condition.hpp */,
+				04F4640426C510E0007CEEAB /* state_machine_number.hpp */,
+				04F4640526C510E0007CEEAB /* animation.hpp */,
+				04F4640626C510E0007CEEAB /* keyframe.hpp */,
+				04F4640726C510E0007CEEAB /* blend_state.hpp */,
+				04F4640826C510E0007CEEAB /* state_machine_layer.hpp */,
+				04F4640926C510E0007CEEAB /* blend_animation_1d.hpp */,
+				04F4640A26C510E0007CEEAB /* state_machine_layer_component.hpp */,
+				04F4640B26C510E0007CEEAB /* blend_state_instance.hpp */,
+				04F4640C26C510E0007CEEAB /* state_machine_bool.hpp */,
+				04F4640D26C510E0007CEEAB /* blend_state_1d.hpp */,
+				04F4640E26C510E0007CEEAB /* state_instance.hpp */,
+				04F4640F26C510E0007CEEAB /* keyed_object.hpp */,
+				04F4641026C510E0007CEEAB /* state_machine_component.hpp */,
+				04F4641126C510E0007CEEAB /* state_machine.hpp */,
+				04F4641226C510E0007CEEAB /* blend_state_1d_instance.hpp */,
+				04F4641326C510E0007CEEAB /* keyframe_bool.hpp */,
+				04F4641426C510E0007CEEAB /* state_machine_input_instance.hpp */,
+				04F4641526C510E0007CEEAB /* transition_condition.hpp */,
+				04F4641626C510E0007CEEAB /* transition_value_condition.hpp */,
+				04F4641726C510E0007CEEAB /* animation_state_instance.hpp */,
+				04F4641826C510E0007CEEAB /* linear_animation.hpp */,
+				04F4641926C510E0007CEEAB /* linear_animation_instance.hpp */,
+				04F4641A26C510E0007CEEAB /* transition_condition_op.hpp */,
+				04F4641B26C510E0007CEEAB /* blend_state_direct_instance.hpp */,
+				04F4641C26C510E0007CEEAB /* keyframe_double.hpp */,
+				04F4641D26C510E0007CEEAB /* blend_animation_direct.hpp */,
+				04F4641E26C510E0007CEEAB /* loop.hpp */,
+				04F4641F26C510E0007CEEAB /* keyframe_color.hpp */,
+				04F4642026C510E0007CEEAB /* entry_state.hpp */,
+				04F4642126C510E0007CEEAB /* blend_animation.hpp */,
+				04F4642226C510E0007CEEAB /* state_machine_instance.hpp */,
+				04F4642326C510E0007CEEAB /* state_transition_flags.hpp */,
+				04F4642426C510E0007CEEAB /* exit_state.hpp */,
+				04F4642526C510E0007CEEAB /* any_state.hpp */,
+				04F4642626C510E0007CEEAB /* animation_state.hpp */,
+				04F4642726C510E0007CEEAB /* blend_state_direct.hpp */,
+				04F4642826C510E0007CEEAB /* transition_trigger_condition.hpp */,
 			);
 			path = animation;
 			sourceTree = "<group>";
 		};
-		04F4617526C4030D007CEEAB /* shapes */ = {
+		04F4642A26C510E0007CEEAB /* shapes */ = {
 			isa = PBXGroup;
 			children = (
-				04F4617626C4030D007CEEAB /* straight_vertex.hpp */,
-				04F4617726C4030D007CEEAB /* paint */,
-				04F4618626C4030D007CEEAB /* path_composer.hpp */,
-				04F4618726C4030D007CEEAB /* shape_paint_container.hpp */,
-				04F4618826C4030D007CEEAB /* cubic_mirrored_vertex.hpp */,
-				04F4618926C4030D007CEEAB /* path_space.hpp */,
-				04F4618A26C4030D007CEEAB /* ellipse.hpp */,
-				04F4618B26C4030D007CEEAB /* clipping_shape.hpp */,
-				04F4618C26C4030D007CEEAB /* metrics_path.hpp */,
-				04F4618D26C4030D007CEEAB /* cubic_vertex.hpp */,
-				04F4618E26C4030D007CEEAB /* shape.hpp */,
-				04F4618F26C4030D007CEEAB /* triangle.hpp */,
-				04F4619026C4030D007CEEAB /* path.hpp */,
-				04F4619126C4030D007CEEAB /* polygon.hpp */,
-				04F4619226C4030D007CEEAB /* path_vertex.hpp */,
-				04F4619326C4030D007CEEAB /* parametric_path.hpp */,
-				04F4619426C4030D007CEEAB /* rectangle.hpp */,
-				04F4619526C4030D007CEEAB /* points_path.hpp */,
-				04F4619626C4030D007CEEAB /* star.hpp */,
-				04F4619726C4030D007CEEAB /* cubic_asymmetric_vertex.hpp */,
-				04F4619826C4030D007CEEAB /* cubic_detached_vertex.hpp */,
+				04F4642B26C510E0007CEEAB /* straight_vertex.hpp */,
+				04F4642C26C510E0007CEEAB /* paint */,
+				04F4643B26C510E0007CEEAB /* path_composer.hpp */,
+				04F4643C26C510E0007CEEAB /* shape_paint_container.hpp */,
+				04F4643D26C510E0007CEEAB /* cubic_mirrored_vertex.hpp */,
+				04F4643E26C510E0007CEEAB /* path_space.hpp */,
+				04F4643F26C510E0007CEEAB /* ellipse.hpp */,
+				04F4644026C510E0007CEEAB /* clipping_shape.hpp */,
+				04F4644126C510E0007CEEAB /* metrics_path.hpp */,
+				04F4644226C510E0007CEEAB /* cubic_vertex.hpp */,
+				04F4644326C510E0007CEEAB /* shape.hpp */,
+				04F4644426C510E0007CEEAB /* triangle.hpp */,
+				04F4644526C510E0007CEEAB /* path.hpp */,
+				04F4644626C510E0007CEEAB /* polygon.hpp */,
+				04F4644726C510E0007CEEAB /* path_vertex.hpp */,
+				04F4644826C510E0007CEEAB /* parametric_path.hpp */,
+				04F4644926C510E0007CEEAB /* rectangle.hpp */,
+				04F4644A26C510E0007CEEAB /* points_path.hpp */,
+				04F4644B26C510E0007CEEAB /* star.hpp */,
+				04F4644C26C510E0007CEEAB /* cubic_asymmetric_vertex.hpp */,
+				04F4644D26C510E0007CEEAB /* cubic_detached_vertex.hpp */,
 			);
 			path = shapes;
 			sourceTree = "<group>";
 		};
-		04F4617726C4030D007CEEAB /* paint */ = {
+		04F4642C26C510E0007CEEAB /* paint */ = {
 			isa = PBXGroup;
 			children = (
-				04F4617826C4030D007CEEAB /* stroke_cap.hpp */,
-				04F4617926C4030D007CEEAB /* gradient_stop.hpp */,
-				04F4617A26C4030D007CEEAB /* stroke.hpp */,
-				04F4617B26C4030D007CEEAB /* shape_paint_mutator.hpp */,
-				04F4617C26C4030D007CEEAB /* blend_mode.hpp */,
-				04F4617D26C4030D007CEEAB /* shape_paint.hpp */,
-				04F4617E26C4030D007CEEAB /* stroke_join.hpp */,
-				04F4617F26C4030D007CEEAB /* fill.hpp */,
-				04F4618026C4030D007CEEAB /* radial_gradient.hpp */,
-				04F4618126C4030D007CEEAB /* trim_path.hpp */,
-				04F4618226C4030D007CEEAB /* color.hpp */,
-				04F4618326C4030D007CEEAB /* solid_color.hpp */,
-				04F4618426C4030D007CEEAB /* linear_gradient.hpp */,
-				04F4618526C4030D007CEEAB /* stroke_effect.hpp */,
+				04F4642D26C510E0007CEEAB /* stroke_cap.hpp */,
+				04F4642E26C510E0007CEEAB /* gradient_stop.hpp */,
+				04F4642F26C510E0007CEEAB /* stroke.hpp */,
+				04F4643026C510E0007CEEAB /* shape_paint_mutator.hpp */,
+				04F4643126C510E0007CEEAB /* blend_mode.hpp */,
+				04F4643226C510E0007CEEAB /* shape_paint.hpp */,
+				04F4643326C510E0007CEEAB /* stroke_join.hpp */,
+				04F4643426C510E0007CEEAB /* fill.hpp */,
+				04F4643526C510E0007CEEAB /* radial_gradient.hpp */,
+				04F4643626C510E0007CEEAB /* trim_path.hpp */,
+				04F4643726C510E0007CEEAB /* color.hpp */,
+				04F4643826C510E0007CEEAB /* solid_color.hpp */,
+				04F4643926C510E0007CEEAB /* linear_gradient.hpp */,
+				04F4643A26C510E0007CEEAB /* stroke_effect.hpp */,
 			);
 			path = paint;
 			sourceTree = "<group>";
 		};
-		04F4619926C4030D007CEEAB /* math */ = {
+		04F4644E26C510E0007CEEAB /* math */ = {
 			isa = PBXGroup;
 			children = (
-				04F4619A26C4030D007CEEAB /* vec2d.hpp */,
-				04F4619B26C4030D007CEEAB /* mat2d.hpp */,
-				04F4619C26C4030D007CEEAB /* aabb.hpp */,
-				04F4619D26C4030D007CEEAB /* color.hpp */,
-				04F4619E26C4030D007CEEAB /* transform_components.hpp */,
-				04F4619F26C4030D007CEEAB /* circle_constant.hpp */,
+				04F4644F26C510E0007CEEAB /* vec2d.hpp */,
+				04F4645026C510E0007CEEAB /* mat2d.hpp */,
+				04F4645126C510E0007CEEAB /* aabb.hpp */,
+				04F4645226C510E0007CEEAB /* color.hpp */,
+				04F4645326C510E0007CEEAB /* transform_components.hpp */,
+				04F4645426C510E0007CEEAB /* circle_constant.hpp */,
 			);
 			path = math;
 			sourceTree = "<group>";
 		};
-		04F461A826C4030D007CEEAB /* bones */ = {
+		04F4645D26C510E0007CEEAB /* bones */ = {
 			isa = PBXGroup;
 			children = (
-				04F461A926C4030D007CEEAB /* tendon.hpp */,
-				04F461AA26C4030D007CEEAB /* skeletal_component.hpp */,
-				04F461AB26C4030D007CEEAB /* weight.hpp */,
-				04F461AC26C4030D007CEEAB /* skin.hpp */,
-				04F461AD26C4030D007CEEAB /* root_bone.hpp */,
-				04F461AE26C4030D007CEEAB /* bone.hpp */,
-				04F461AF26C4030D007CEEAB /* skinnable.hpp */,
-				04F461B026C4030D007CEEAB /* cubic_weight.hpp */,
+				04F4645E26C510E0007CEEAB /* tendon.hpp */,
+				04F4645F26C510E0007CEEAB /* skeletal_component.hpp */,
+				04F4646026C510E0007CEEAB /* weight.hpp */,
+				04F4646126C510E0007CEEAB /* skin.hpp */,
+				04F4646226C510E0007CEEAB /* root_bone.hpp */,
+				04F4646326C510E0007CEEAB /* bone.hpp */,
+				04F4646426C510E0007CEEAB /* skinnable.hpp */,
+				04F4646526C510E0007CEEAB /* cubic_weight.hpp */,
 			);
 			path = bones;
 			sourceTree = "<group>";
@@ -1370,6 +1442,7 @@
 		C9A9DA28265C51A40005DB1F /* animation */ = {
 			isa = PBXGroup;
 			children = (
+				04F4656126C514AC007CEEAB /* keyframe_bool_base.cpp */,
 				04F1C92B26A84B8700CEE6BE /* blend_animation_1d_base.cpp */,
 				04F1C92A26A84B8700CEE6BE /* blend_animation_direct_base.cpp */,
 				04F1C92D26A84B8700CEE6BE /* blend_state_1d_base.cpp */,
@@ -1543,7 +1616,7 @@
 		C9C7406C24FC4EF400EF9516 /* Rive */ = {
 			isa = PBXGroup;
 			children = (
-				04F460A726C401B9007CEEAB /* include */,
+				04F4636E26C510E0007CEEAB /* include */,
 				C9C7406D24FC4F0400EF9516 /* src */,
 			);
 			name = Rive;
@@ -1552,6 +1625,7 @@
 		C9C7406D24FC4F0400EF9516 /* src */ = {
 			isa = PBXGroup;
 			children = (
+				04F4655926C51422007CEEAB /* world_transform_component.cpp */,
 				04F1C92026A84B5200CEE6BE /* constraints */,
 				C9A9DA25265C51A40005DB1F /* generated */,
 				C9C7407A24FC4F0400EF9516 /* animation */,
@@ -1604,6 +1678,7 @@
 		C9C7407A24FC4F0400EF9516 /* animation */ = {
 			isa = PBXGroup;
 			children = (
+				04F4656326C514B7007CEEAB /* keyframe_bool.cpp */,
 				C9A9DA0F265C510F0005DB1F /* animation_state_instance.cpp */,
 				C9A9DA12265C510F0005DB1F /* blend_animation_1d.cpp */,
 				C9A9DA0D265C510F0005DB1F /* blend_animation_direct.cpp */,
@@ -1729,236 +1804,252 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				04F4627126C4030D007CEEAB /* points_path.hpp in Headers */,
-				04F461DD26C4030D007CEEAB /* blend_state_1d_base.hpp in Headers */,
-				04F4622226C4030D007CEEAB /* container_component.hpp in Headers */,
-				04F4626226C4030D007CEEAB /* path_composer.hpp in Headers */,
-				04F4623E26C4030D007CEEAB /* transition_condition.hpp in Headers */,
+				04F4650726C510E1007CEEAB /* linear_animation_instance.hpp in Headers */,
+				04F464A526C510E1007CEEAB /* gradient_stop_base.hpp in Headers */,
+				04F4648E26C510E1007CEEAB /* state_machine_number_base.hpp in Headers */,
+				04F4646D26C510E0007CEEAB /* constraint_base.hpp in Headers */,
+				04F4651C26C510E1007CEEAB /* shape_paint_mutator.hpp in Headers */,
+				04F464A426C510E1007CEEAB /* radial_gradient_base.hpp in Headers */,
+				04F4647026C510E0007CEEAB /* scale_constraint_base.hpp in Headers */,
+				04F464D726C510E1007CEEAB /* renderer.hpp in Headers */,
+				04F4655126C510E1007CEEAB /* core.hpp in Headers */,
+				04F4654826C510E1007CEEAB /* tendon.hpp in Headers */,
+				04F4646C26C510E0007CEEAB /* rotation_constraint_base.hpp in Headers */,
+				04F464A126C510E1007CEEAB /* shape_paint_base.hpp in Headers */,
+				04F4647E26C510E1007CEEAB /* keyframe_base.hpp in Headers */,
+				04F4647F26C510E1007CEEAB /* animation_state_base.hpp in Headers */,
+				04F4654B26C510E1007CEEAB /* skin.hpp in Headers */,
+				04F4652126C510E1007CEEAB /* radial_gradient.hpp in Headers */,
+				04F464C426C510E1007CEEAB /* core_color_type.hpp in Headers */,
+				04F464AF26C510E1007CEEAB /* star_base.hpp in Headers */,
+				04F4649426C510E1007CEEAB /* transition_bool_condition_base.hpp in Headers */,
+				04F4646F26C510E0007CEEAB /* translation_constraint_base.hpp in Headers */,
+				04F464DF26C510E1007CEEAB /* layer_state_importer.hpp in Headers */,
 				046FB7F7264EAA60000129B1 /* RiveFile.h in Headers */,
-				04F4622326C4030D007CEEAB /* transition_bool_condition.hpp in Headers */,
+				04F464B426C510E1007CEEAB /* clipping_shape_base.hpp in Headers */,
 				046FB7FC264EAA61000129B1 /* RiveArtboard.h in Headers */,
-				04F461BA26C4030D007CEEAB /* transform_constraint_base.hpp in Headers */,
-				04F461EC26C4030D007CEEAB /* ellipse_base.hpp in Headers */,
-				04F461C726C4030D007CEEAB /* linear_animation_base.hpp in Headers */,
-				04F461F526C4030D007CEEAB /* polygon_base.hpp in Headers */,
 				046FB7FD264EAA61000129B1 /* RiveLinearAnimation.h in Headers */,
-				04F461E626C4030D007CEEAB /* trim_path_base.hpp in Headers */,
-				04F4627A26C4030D007CEEAB /* circle_constant.hpp in Headers */,
-				04F4620F26C4030D007CEEAB /* constraint.hpp in Headers */,
-				04F461F426C4030D007CEEAB /* path_base.hpp in Headers */,
-				04F4625126C4030D007CEEAB /* transition_trigger_condition.hpp in Headers */,
-				04F4627526C4030D007CEEAB /* vec2d.hpp in Headers */,
-				04F461F126C4030D007CEEAB /* cubic_mirrored_vertex_base.hpp in Headers */,
-				04F461EA26C4030D007CEEAB /* cubic_asymmetric_vertex_base.hpp in Headers */,
-				04F4627026C4030D007CEEAB /* rectangle.hpp in Headers */,
-				04F4624D26C4030D007CEEAB /* exit_state.hpp in Headers */,
-				04F4624F26C4030D007CEEAB /* animation_state.hpp in Headers */,
-				04F4626126C4030D007CEEAB /* stroke_effect.hpp in Headers */,
-				04F461EE26C4030D007CEEAB /* triangle_base.hpp in Headers */,
-				04F4621B26C4030D007CEEAB /* import_stack.hpp in Headers */,
-				04F4622A26C4030D007CEEAB /* state_machine_trigger.hpp in Headers */,
-				04F461F726C4030D007CEEAB /* clipping_shape_base.hpp in Headers */,
-				04F461CF26C4030D007CEEAB /* keyed_object_base.hpp in Headers */,
-				04F461FB26C4030D007CEEAB /* weight_base.hpp in Headers */,
-				04F4620026C4030D007CEEAB /* tendon_base.hpp in Headers */,
-				04F4626026C4030D007CEEAB /* linear_gradient.hpp in Headers */,
-				04F4620D26C4030D007CEEAB /* status_code.hpp in Headers */,
-				04F4622526C4030D007CEEAB /* keyed_property.hpp in Headers */,
-				04F4627426C4030D007CEEAB /* cubic_detached_vertex.hpp in Headers */,
-				04F4620726C4030D007CEEAB /* core_color_type.hpp in Headers */,
-				04F461D726C4030D007CEEAB /* transition_bool_condition_base.hpp in Headers */,
-				04F4623226C4030D007CEEAB /* state_machine_layer.hpp in Headers */,
-				04F4628C26C4030D007CEEAB /* core.hpp in Headers */,
-				04F4621226C4030D007CEEAB /* distance_constraint.hpp in Headers */,
-				04F4620626C4030D007CEEAB /* reader.h in Headers */,
-				04F4625B26C4030D007CEEAB /* fill.hpp in Headers */,
-				04F4626F26C4030D007CEEAB /* parametric_path.hpp in Headers */,
-				04F461E326C4030D007CEEAB /* fill_base.hpp in Headers */,
-				04F4622926C4030D007CEEAB /* system_state_instance.hpp in Headers */,
-				04F4625026C4030D007CEEAB /* blend_state_direct.hpp in Headers */,
-				04F4628D26C4030D007CEEAB /* transform_component.hpp in Headers */,
-				04F461B626C4030D007CEEAB /* transform_component_base.hpp in Headers */,
+				04F4648226C510E1007CEEAB /* transition_number_condition_base.hpp in Headers */,
+				04F4650E26C510E1007CEEAB /* entry_state.hpp in Headers */,
+				04F4653F26C510E1007CEEAB /* circle_constant.hpp in Headers */,
+				04F4650626C510E1007CEEAB /* linear_animation.hpp in Headers */,
+				04F4652826C510E1007CEEAB /* shape_paint_container.hpp in Headers */,
+				04F464DD26C510E1007CEEAB /* linear_animation_importer.hpp in Headers */,
+				04F464EC26C510E1007CEEAB /* state_transition.hpp in Headers */,
+				04F464D926C510E1007CEEAB /* state_transition_importer.hpp in Headers */,
+				04F464EB26C510E1007CEEAB /* layer_state.hpp in Headers */,
+				04F4652C26C510E1007CEEAB /* clipping_shape.hpp in Headers */,
+				04F4650226C510E1007CEEAB /* state_machine_input_instance.hpp in Headers */,
+				04F4649A26C510E1007CEEAB /* blend_state_1d_base.hpp in Headers */,
+				04F4648A26C510E1007CEEAB /* keyframe_id_base.hpp in Headers */,
+				04F464AD26C510E1007CEEAB /* rectangle_base.hpp in Headers */,
+				04F4646B26C510E0007CEEAB /* transform_component_base.hpp in Headers */,
 				046FB800264EAA61000129B1 /* RiveStateMachineInstance.h in Headers */,
-				04F461EF26C4030D007CEEAB /* shape_base.hpp in Headers */,
-				04F4623426C4030D007CEEAB /* state_machine_layer_component.hpp in Headers */,
-				04F461D826C4030D007CEEAB /* transition_trigger_condition_base.hpp in Headers */,
-				04F4624826C4030D007CEEAB /* keyframe_color.hpp in Headers */,
-				04F461ED26C4030D007CEEAB /* points_path_base.hpp in Headers */,
+				04F4647526C510E1007CEEAB /* distance_constraint_base.hpp in Headers */,
+				04F4650326C510E1007CEEAB /* transition_condition.hpp in Headers */,
+				04F464FA26C510E1007CEEAB /* state_machine_bool.hpp in Headers */,
+				04F4649626C510E1007CEEAB /* state_machine_component_base.hpp in Headers */,
+				04F4654626C510E1007CEEAB /* dependency_sorter.hpp in Headers */,
+				04F4647726C510E1007CEEAB /* artboard_base.hpp in Headers */,
 				046FB7FB264EAA61000129B1 /* RiveSMIInput.h in Headers */,
-				04F4622726C4030D007CEEAB /* layer_state.hpp in Headers */,
-				04F4624926C4030D007CEEAB /* entry_state.hpp in Headers */,
-				04F4623526C4030D007CEEAB /* blend_state_instance.hpp in Headers */,
-				04F4623B26C4030D007CEEAB /* state_machine.hpp in Headers */,
-				04F4624026C4030D007CEEAB /* animation_state_instance.hpp in Headers */,
-				04F4620C26C4030D007CEEAB /* binary_reader.hpp in Headers */,
-				04F4626826C4030D007CEEAB /* metrics_path.hpp in Headers */,
-				04F4622426C4030D007CEEAB /* cubic_interpolator.hpp in Headers */,
-				04F461D426C4030D007CEEAB /* state_machine_bool_base.hpp in Headers */,
-				04F4621726C4030D007CEEAB /* state_machine_layer_importer.hpp in Headers */,
-				04F4625426C4030D007CEEAB /* stroke_cap.hpp in Headers */,
-				04F461C126C4030D007CEEAB /* keyframe_base.hpp in Headers */,
-				04F461B926C4030D007CEEAB /* ik_constraint_base.hpp in Headers */,
-				04F4623326C4030D007CEEAB /* blend_animation_1d.hpp in Headers */,
-				04F4623626C4030D007CEEAB /* state_machine_bool.hpp in Headers */,
-				04F461CC26C4030D007CEEAB /* state_machine_layer_base.hpp in Headers */,
-				04F4625E26C4030D007CEEAB /* color.hpp in Headers */,
-				04F461C226C4030D007CEEAB /* animation_state_base.hpp in Headers */,
-				04F461D026C4030D007CEEAB /* transition_value_condition_base.hpp in Headers */,
+				04F464EA26C510E1007CEEAB /* state_machine_input.hpp in Headers */,
 				046FB7FE264EAA61000129B1 /* RiveStateMachine.h in Headers */,
-				04F461BF26C4030D007CEEAB /* keyframe_color_base.hpp in Headers */,
+				04F4653D26C510E1007CEEAB /* color.hpp in Headers */,
+				04F464B626C510E1007CEEAB /* container_component_base.hpp in Headers */,
+				04F464B526C510E1007CEEAB /* path_vertex_base.hpp in Headers */,
+				04F464C626C510E1007CEEAB /* core_double_type.hpp in Headers */,
+				04F464E326C510E1007CEEAB /* draw_target.hpp in Headers */,
+				04F464CA26C510E1007CEEAB /* status_code.hpp in Headers */,
+				04F4653526C510E1007CEEAB /* rectangle.hpp in Headers */,
+				04F4654026C510E1007CEEAB /* command_path.hpp in Headers */,
+				04F4650A26C510E1007CEEAB /* keyframe_double.hpp in Headers */,
 				046FB7F3264EAA60000129B1 /* RiveStateMachineInput.h in Headers */,
-				04F4620526C4030D007CEEAB /* backboard.hpp in Headers */,
-				04F4621C26C4030D007CEEAB /* layer_state_importer.hpp in Headers */,
-				04F4623926C4030D007CEEAB /* keyed_object.hpp in Headers */,
-				04F4626926C4030D007CEEAB /* cubic_vertex.hpp in Headers */,
-				04F4625C26C4030D007CEEAB /* radial_gradient.hpp in Headers */,
-				04F4626426C4030D007CEEAB /* cubic_mirrored_vertex.hpp in Headers */,
-				04F4625A26C4030D007CEEAB /* stroke_join.hpp in Headers */,
-				04F4620826C4030D007CEEAB /* core_uint_type.hpp in Headers */,
-				04F4627326C4030D007CEEAB /* cubic_asymmetric_vertex.hpp in Headers */,
-				04F4627726C4030D007CEEAB /* aabb.hpp in Headers */,
-				04F461B726C4030D007CEEAB /* constraint_base.hpp in Headers */,
-				04F4621026C4030D007CEEAB /* ik_constraint.hpp in Headers */,
-				04F4620326C4030D007CEEAB /* backboard_base.hpp in Headers */,
-				04F4624A26C4030D007CEEAB /* blend_animation.hpp in Headers */,
-				04F4626E26C4030D007CEEAB /* path_vertex.hpp in Headers */,
-				04F4620926C4030D007CEEAB /* core_double_type.hpp in Headers */,
-				04F4622E26C4030D007CEEAB /* state_machine_number.hpp in Headers */,
-				04F4628026C4030D007CEEAB /* artboard.hpp in Headers */,
-				04F4628A26C4030D007CEEAB /* cubic_weight.hpp in Headers */,
-				04F4628926C4030D007CEEAB /* skinnable.hpp in Headers */,
-				04F4623826C4030D007CEEAB /* state_instance.hpp in Headers */,
-				04F461E926C4030D007CEEAB /* parametric_path_base.hpp in Headers */,
-				04F461C926C4030D007CEEAB /* layer_state_base.hpp in Headers */,
-				04F4621626C4030D007CEEAB /* state_transition_importer.hpp in Headers */,
-				04F4628126C4030D007CEEAB /* dependency_sorter.hpp in Headers */,
-				04F4625626C4030D007CEEAB /* stroke.hpp in Headers */,
-				04F461C626C4030D007CEEAB /* cubic_interpolator_base.hpp in Headers */,
-				04F461CA26C4030D007CEEAB /* state_machine_layer_component_base.hpp in Headers */,
-				04F4623126C4030D007CEEAB /* blend_state.hpp in Headers */,
-				04F461C326C4030D007CEEAB /* animation_base.hpp in Headers */,
-				04F461F626C4030D007CEEAB /* cubic_detached_vertex_base.hpp in Headers */,
-				04F4625726C4030D007CEEAB /* shape_paint_mutator.hpp in Headers */,
-				04F4628726C4030D007CEEAB /* root_bone.hpp in Headers */,
-				04F461B526C4030D007CEEAB /* node_base.hpp in Headers */,
-				04F461FC26C4030D007CEEAB /* root_bone_base.hpp in Headers */,
-				04F461BE26C4030D007CEEAB /* blend_animation_base.hpp in Headers */,
-				04F4624B26C4030D007CEEAB /* state_machine_instance.hpp in Headers */,
-				04F461D126C4030D007CEEAB /* state_machine_number_base.hpp in Headers */,
-				04F461D526C4030D007CEEAB /* blend_state_transition_base.hpp in Headers */,
-				04F461E426C4030D007CEEAB /* shape_paint_base.hpp in Headers */,
-				04F4625226C4030D007CEEAB /* transform_space.hpp in Headers */,
-				04F461C826C4030D007CEEAB /* entry_state_base.hpp in Headers */,
-				04F461E726C4030D007CEEAB /* radial_gradient_base.hpp in Headers */,
-				04F4627D26C4030D007CEEAB /* node.hpp in Headers */,
-				04F4628426C4030D007CEEAB /* skeletal_component.hpp in Headers */,
-				04F4627E26C4030D007CEEAB /* layout.hpp in Headers */,
-				04F461CB26C4030D007CEEAB /* blend_state_direct_base.hpp in Headers */,
-				04F4624326C4030D007CEEAB /* transition_condition_op.hpp in Headers */,
-				04F4621F26C4030D007CEEAB /* draw_target.hpp in Headers */,
-				04F4628826C4030D007CEEAB /* bone.hpp in Headers */,
-				04F4621E26C4030D007CEEAB /* state_machine_importer.hpp in Headers */,
-				04F4622F26C4030D007CEEAB /* animation.hpp in Headers */,
-				04F4626526C4030D007CEEAB /* path_space.hpp in Headers */,
-				04F4628226C4030D007CEEAB /* core_context.hpp in Headers */,
-				04F4627926C4030D007CEEAB /* transform_components.hpp in Headers */,
-				04F4624726C4030D007CEEAB /* loop.hpp in Headers */,
-				04F4624626C4030D007CEEAB /* blend_animation_direct.hpp in Headers */,
-				04F461B826C4030D007CEEAB /* targeted_constraint_base.hpp in Headers */,
-				04F461FF26C4030D007CEEAB /* skin_base.hpp in Headers */,
-				04F4628626C4030D007CEEAB /* skin.hpp in Headers */,
-				04F4625526C4030D007CEEAB /* gradient_stop.hpp in Headers */,
-				04F461F226C4030D007CEEAB /* star_base.hpp in Headers */,
-				04F461D226C4030D007CEEAB /* state_transition_base.hpp in Headers */,
-				04F4622C26C4030D007CEEAB /* blend_state_transition.hpp in Headers */,
-				04F4620A26C4030D007CEEAB /* core_string_type.hpp in Headers */,
-				04F4624226C4030D007CEEAB /* linear_animation_instance.hpp in Headers */,
-				04F461E026C4030D007CEEAB /* exit_state_base.hpp in Headers */,
-				04F4620426C4030D007CEEAB /* drawable_base.hpp in Headers */,
-				04F4628B26C4030D007CEEAB /* draw_rules.hpp in Headers */,
-				04F4626626C4030D007CEEAB /* ellipse.hpp in Headers */,
-				04F4622126C4030D007CEEAB /* file.hpp in Headers */,
-				04F4621826C4030D007CEEAB /* keyed_property_importer.hpp in Headers */,
-				04F461F026C4030D007CEEAB /* rectangle_base.hpp in Headers */,
-				04F461BC26C4030D007CEEAB /* artboard_base.hpp in Headers */,
-				04F4628526C4030D007CEEAB /* weight.hpp in Headers */,
-				04F4627626C4030D007CEEAB /* mat2d.hpp in Headers */,
-				04F461DF26C4030D007CEEAB /* state_machine_base.hpp in Headers */,
-				04F4622626C4030D007CEEAB /* state_machine_input.hpp in Headers */,
-				04F461FD26C4030D007CEEAB /* cubic_weight_base.hpp in Headers */,
-				04F461E526C4030D007CEEAB /* solid_color_base.hpp in Headers */,
-				04F4625826C4030D007CEEAB /* blend_mode.hpp in Headers */,
-				04F4621326C4030D007CEEAB /* component_dirt.hpp in Headers */,
+				04F464F226C510E1007CEEAB /* state_machine_number.hpp in Headers */,
+				04F464AB26C510E1007CEEAB /* triangle_base.hpp in Headers */,
+				04F4654A26C510E1007CEEAB /* weight.hpp in Headers */,
+				04F4646E26C510E0007CEEAB /* targeted_constraint_base.hpp in Headers */,
+				04F464D626C510E1007CEEAB /* component_dirt.hpp in Headers */,
+				04F4651626C510E1007CEEAB /* transition_trigger_condition.hpp in Headers */,
+				04F4647826C510E1007CEEAB /* draw_rules_base.hpp in Headers */,
+				04F4650426C510E1007CEEAB /* transition_value_condition.hpp in Headers */,
+				04F464F826C510E1007CEEAB /* state_machine_layer_component.hpp in Headers */,
+				04F4653A26C510E1007CEEAB /* vec2d.hpp in Headers */,
+				04F464C326C510E1007CEEAB /* reader.h in Headers */,
+				04F4651F26C510E1007CEEAB /* stroke_join.hpp in Headers */,
+				04F4651726C510E1007CEEAB /* transform_space.hpp in Headers */,
+				04F4649E26C510E1007CEEAB /* linear_gradient_base.hpp in Headers */,
+				04F464EE26C510E1007CEEAB /* state_machine_trigger.hpp in Headers */,
+				04F4652F26C510E1007CEEAB /* shape.hpp in Headers */,
+				04F4651126C510E1007CEEAB /* state_transition_flags.hpp in Headers */,
+				04F464E826C510E1007CEEAB /* cubic_interpolator.hpp in Headers */,
+				04F464C826C510E1007CEEAB /* core_bool_type.hpp in Headers */,
+				04F4654E26C510E1007CEEAB /* skinnable.hpp in Headers */,
+				04F4654D26C510E1007CEEAB /* bone.hpp in Headers */,
+				04F4646A26C510E0007CEEAB /* node_base.hpp in Headers */,
+				04F4647426C510E1007CEEAB /* transform_space_constraint_base.hpp in Headers */,
+				04F4648626C510E1007CEEAB /* layer_state_base.hpp in Headers */,
+				04F4649C26C510E1007CEEAB /* state_machine_base.hpp in Headers */,
+				04F464ED26C510E1007CEEAB /* system_state_instance.hpp in Headers */,
+				04F4647A26C510E1007CEEAB /* blend_animation_base.hpp in Headers */,
+				04F4652726C510E1007CEEAB /* path_composer.hpp in Headers */,
 				046FB7F1264EAA60000129B1 /* RiveLinearAnimationInstance.h in Headers */,
-				04F4621526C4030D007CEEAB /* draw_target_placement.hpp in Headers */,
-				04F4626C26C4030D007CEEAB /* path.hpp in Headers */,
-				04F461C026C4030D007CEEAB /* keyed_property_base.hpp in Headers */,
-				04F461CD26C4030D007CEEAB /* keyframe_id_base.hpp in Headers */,
-				04F461E126C4030D007CEEAB /* linear_gradient_base.hpp in Headers */,
-				04F461C526C4030D007CEEAB /* transition_number_condition_base.hpp in Headers */,
-				04F4626B26C4030D007CEEAB /* triangle.hpp in Headers */,
-				04F4621426C4030D007CEEAB /* renderer.hpp in Headers */,
-				04F4620B26C4030D007CEEAB /* core_bool_type.hpp in Headers */,
-				04F4620E26C4030D007CEEAB /* targeted_constraint.hpp in Headers */,
-				04F461DB26C4030D007CEEAB /* transition_condition_base.hpp in Headers */,
-				04F4626726C4030D007CEEAB /* clipping_shape.hpp in Headers */,
-				04F461F926C4030D007CEEAB /* container_component_base.hpp in Headers */,
-				04F4625326C4030D007CEEAB /* straight_vertex.hpp in Headers */,
-				04F4626326C4030D007CEEAB /* shape_paint_container.hpp in Headers */,
-				04F461B426C4030D007CEEAB /* core_registry.hpp in Headers */,
-				04F461C426C4030D007CEEAB /* blend_state_base.hpp in Headers */,
-				04F461EB26C4030D007CEEAB /* cubic_vertex_base.hpp in Headers */,
-				04F4623726C4030D007CEEAB /* blend_state_1d.hpp in Headers */,
-				04F4624C26C4030D007CEEAB /* state_transition_flags.hpp in Headers */,
-				04F4620126C4030D007CEEAB /* skeletal_component_base.hpp in Headers */,
-				04F4624426C4030D007CEEAB /* blend_state_direct_instance.hpp in Headers */,
-				04F4623026C4030D007CEEAB /* keyframe.hpp in Headers */,
-				04F461F826C4030D007CEEAB /* path_vertex_base.hpp in Headers */,
-				04F4621D26C4030D007CEEAB /* artboard_importer.hpp in Headers */,
-				04F4623A26C4030D007CEEAB /* state_machine_component.hpp in Headers */,
+				04F464FE26C510E1007CEEAB /* state_machine_component.hpp in Headers */,
+				04F4651926C510E1007CEEAB /* stroke_cap.hpp in Headers */,
+				04F464D226C510E1007CEEAB /* ik_constraint.hpp in Headers */,
+				04F4653926C510E1007CEEAB /* cubic_detached_vertex.hpp in Headers */,
+				04F4654F26C510E1007CEEAB /* cubic_weight.hpp in Headers */,
+				04F464E626C510E1007CEEAB /* container_component.hpp in Headers */,
+				04F464CB26C510E1007CEEAB /* translation_constraint.hpp in Headers */,
+				04F4654226C510E1007CEEAB /* node.hpp in Headers */,
+				04F4654126C510E1007CEEAB /* component.hpp in Headers */,
+				04F4648F26C510E1007CEEAB /* state_transition_base.hpp in Headers */,
+				04F4647126C510E1007CEEAB /* ik_constraint_base.hpp in Headers */,
+				04F4650526C510E1007CEEAB /* animation_state_instance.hpp in Headers */,
+				04F464AE26C510E1007CEEAB /* cubic_mirrored_vertex_base.hpp in Headers */,
+				04F464D326C510E1007CEEAB /* transform_component_constraint_y.hpp in Headers */,
+				04F464A926C510E1007CEEAB /* ellipse_base.hpp in Headers */,
+				04F464C726C510E1007CEEAB /* core_string_type.hpp in Headers */,
+				04F4646926C510E0007CEEAB /* core_registry.hpp in Headers */,
+				04F464D426C510E1007CEEAB /* transform_constraint.hpp in Headers */,
 				04BE5430264D1F4100427B39 /* LayerState.h in Headers */,
+				04F4649926C510E1007CEEAB /* state_machine_input_base.hpp in Headers */,
+				04F464CC26C510E1007CEEAB /* scale_constraint.hpp in Headers */,
+				04F4654326C510E1007CEEAB /* layout.hpp in Headers */,
+				04F4648326C510E1007CEEAB /* cubic_interpolator_base.hpp in Headers */,
+				04F4653226C510E1007CEEAB /* polygon.hpp in Headers */,
+				04F4650926C510E1007CEEAB /* blend_state_direct_instance.hpp in Headers */,
+				04F4650B26C510E1007CEEAB /* blend_animation_direct.hpp in Headers */,
+				04F464A626C510E1007CEEAB /* parametric_path_base.hpp in Headers */,
+				04F464F726C510E1007CEEAB /* blend_animation_1d.hpp in Headers */,
+				04F464E726C510E1007CEEAB /* transition_bool_condition.hpp in Headers */,
+				04F4651326C510E1007CEEAB /* any_state.hpp in Headers */,
+				04F4649726C510E1007CEEAB /* any_state_base.hpp in Headers */,
+				04F464BC26C510E1007CEEAB /* skin_base.hpp in Headers */,
+				04F4648C26C510E1007CEEAB /* keyed_object_base.hpp in Headers */,
+				04F4648726C510E1007CEEAB /* state_machine_layer_component_base.hpp in Headers */,
+				04F4647D26C510E1007CEEAB /* keyed_property_base.hpp in Headers */,
+				04F464AC26C510E1007CEEAB /* shape_base.hpp in Headers */,
+				04F464EF26C510E1007CEEAB /* keyframe_id.hpp in Headers */,
+				04F464B726C510E1007CEEAB /* component_base.hpp in Headers */,
+				04F4651026C510E1007CEEAB /* state_machine_instance.hpp in Headers */,
+				04F4652E26C510E1007CEEAB /* cubic_vertex.hpp in Headers */,
+				04F464E926C510E1007CEEAB /* keyed_property.hpp in Headers */,
+				04F4647B26C510E1007CEEAB /* keyframe_bool_base.hpp in Headers */,
+				04F464A326C510E1007CEEAB /* trim_path_base.hpp in Headers */,
+				04F4652B26C510E1007CEEAB /* ellipse.hpp in Headers */,
+				04F464DC26C510E1007CEEAB /* keyed_object_importer.hpp in Headers */,
+				04F464DE26C510E1007CEEAB /* import_stack.hpp in Headers */,
+				04F4652926C510E1007CEEAB /* cubic_mirrored_vertex.hpp in Headers */,
+				04F4648B26C510E1007CEEAB /* blend_animation_1d_base.hpp in Headers */,
+				04F464BD26C510E1007CEEAB /* tendon_base.hpp in Headers */,
+				04F4650826C510E1007CEEAB /* transition_condition_op.hpp in Headers */,
+				04F464DB26C510E1007CEEAB /* keyed_property_importer.hpp in Headers */,
+				04F4652326C510E1007CEEAB /* color.hpp in Headers */,
 				C9C741F424FC510200EF9516 /* Rive.h in Headers */,
-				04F4625926C4030D007CEEAB /* shape_paint.hpp in Headers */,
-				04F4624126C4030D007CEEAB /* linear_animation.hpp in Headers */,
-				04F4623D26C4030D007CEEAB /* state_machine_input_instance.hpp in Headers */,
-				04F461D926C4030D007CEEAB /* state_machine_component_base.hpp in Headers */,
-				04F4621926C4030D007CEEAB /* keyed_object_importer.hpp in Headers */,
-				04F4620226C4030D007CEEAB /* draw_target_base.hpp in Headers */,
-				04F4623F26C4030D007CEEAB /* transition_value_condition.hpp in Headers */,
-				04F4627B26C4030D007CEEAB /* command_path.hpp in Headers */,
-				04F4627C26C4030D007CEEAB /* component.hpp in Headers */,
-				04F461FE26C4030D007CEEAB /* bone_base.hpp in Headers */,
-				04F4622B26C4030D007CEEAB /* keyframe_id.hpp in Headers */,
-				04F4623C26C4030D007CEEAB /* blend_state_1d_instance.hpp in Headers */,
-				04F461F326C4030D007CEEAB /* straight_vertex_base.hpp in Headers */,
+				04F4654C26C510E1007CEEAB /* root_bone.hpp in Headers */,
+				04F464A026C510E1007CEEAB /* fill_base.hpp in Headers */,
+				04F464D826C510E1007CEEAB /* draw_target_placement.hpp in Headers */,
+				04F4651B26C510E1007CEEAB /* stroke.hpp in Headers */,
+				04F4651E26C510E1007CEEAB /* shape_paint.hpp in Headers */,
+				04F4653C26C510E1007CEEAB /* aabb.hpp in Headers */,
+				04F4649126C510E1007CEEAB /* state_machine_bool_base.hpp in Headers */,
+				04F4651D26C510E1007CEEAB /* blend_mode.hpp in Headers */,
+				04F4652526C510E1007CEEAB /* linear_gradient.hpp in Headers */,
+				04F4651426C510E1007CEEAB /* animation_state.hpp in Headers */,
+				04F4651226C510E1007CEEAB /* exit_state.hpp in Headers */,
+				04F464C926C510E1007CEEAB /* binary_reader.hpp in Headers */,
+				04F464F026C510E1007CEEAB /* blend_state_transition.hpp in Headers */,
+				04F4651A26C510E1007CEEAB /* gradient_stop.hpp in Headers */,
+				04F4649226C510E1007CEEAB /* blend_state_transition_base.hpp in Headers */,
+				04F4649D26C510E1007CEEAB /* exit_state_base.hpp in Headers */,
+				04F464D026C510E1007CEEAB /* transform_component_constraint.hpp in Headers */,
+				04F464D126C510E1007CEEAB /* transform_space_constraint.hpp in Headers */,
+				04F4653026C510E1007CEEAB /* triangle.hpp in Headers */,
+				04F464B026C510E1007CEEAB /* straight_vertex_base.hpp in Headers */,
+				04F4649826C510E1007CEEAB /* transition_condition_base.hpp in Headers */,
+				04F4653826C510E1007CEEAB /* cubic_asymmetric_vertex.hpp in Headers */,
+				04F4653326C510E1007CEEAB /* path_vertex.hpp in Headers */,
+				04F4652426C510E1007CEEAB /* solid_color.hpp in Headers */,
+				04F4647C26C510E1007CEEAB /* keyframe_color_base.hpp in Headers */,
+				04F464C526C510E1007CEEAB /* core_uint_type.hpp in Headers */,
+				04F464BA26C510E1007CEEAB /* cubic_weight_base.hpp in Headers */,
+				04F4647226C510E1007CEEAB /* transform_constraint_base.hpp in Headers */,
+				04F464BB26C510E1007CEEAB /* bone_base.hpp in Headers */,
+				04F464CD26C510E1007CEEAB /* targeted_constraint.hpp in Headers */,
+				04F4653726C510E1007CEEAB /* star.hpp in Headers */,
+				04F4651526C510E1007CEEAB /* blend_state_direct.hpp in Headers */,
+				04F464B126C510E1007CEEAB /* path_base.hpp in Headers */,
+				04F464B226C510E1007CEEAB /* polygon_base.hpp in Headers */,
+				04F464A726C510E1007CEEAB /* cubic_asymmetric_vertex_base.hpp in Headers */,
+				04F4648026C510E1007CEEAB /* animation_base.hpp in Headers */,
+				04F464F126C510E1007CEEAB /* transition_number_condition.hpp in Headers */,
+				04F464FD26C510E1007CEEAB /* keyed_object.hpp in Headers */,
+				04F4654726C510E1007CEEAB /* core_context.hpp in Headers */,
 				04BE5436264D2A7500427B39 /* RivePrivateHeaders.h in Headers */,
-				04F4624E26C4030D007CEEAB /* any_state.hpp in Headers */,
-				04F4621A26C4030D007CEEAB /* linear_animation_importer.hpp in Headers */,
-				04F4626A26C4030D007CEEAB /* shape.hpp in Headers */,
-				04F461E226C4030D007CEEAB /* stroke_base.hpp in Headers */,
-				04F4625F26C4030D007CEEAB /* solid_color.hpp in Headers */,
-				04F4627226C4030D007CEEAB /* star.hpp in Headers */,
-				04F4627F26C4030D007CEEAB /* drawable.hpp in Headers */,
+				04F464B926C510E1007CEEAB /* root_bone_base.hpp in Headers */,
+				04F4650F26C510E1007CEEAB /* blend_animation.hpp in Headers */,
+				04F4647626C510E1007CEEAB /* transform_component_constraint_base.hpp in Headers */,
+				04F4653626C510E1007CEEAB /* points_path.hpp in Headers */,
+				04F4650126C510E1007CEEAB /* keyframe_bool.hpp in Headers */,
+				04F464C226C510E1007CEEAB /* backboard.hpp in Headers */,
+				04F464BF26C510E1007CEEAB /* draw_target_base.hpp in Headers */,
+				04F4648426C510E1007CEEAB /* linear_animation_base.hpp in Headers */,
+				04F4654426C510E1007CEEAB /* drawable.hpp in Headers */,
+				04F4654926C510E1007CEEAB /* skeletal_component.hpp in Headers */,
+				04F4648826C510E1007CEEAB /* blend_state_direct_base.hpp in Headers */,
+				04F464DA26C510E1007CEEAB /* state_machine_layer_importer.hpp in Headers */,
+				04F4648526C510E1007CEEAB /* entry_state_base.hpp in Headers */,
+				04F4647326C510E1007CEEAB /* transform_component_constraint_y_base.hpp in Headers */,
+				04F4652A26C510E1007CEEAB /* path_space.hpp in Headers */,
+				04F464A826C510E1007CEEAB /* cubic_vertex_base.hpp in Headers */,
+				04F4653426C510E1007CEEAB /* parametric_path.hpp in Headers */,
+				04F464A226C510E1007CEEAB /* solid_color_base.hpp in Headers */,
+				04F464E226C510E1007CEEAB /* world_transform_component.hpp in Headers */,
+				04F464BE26C510E1007CEEAB /* skeletal_component_base.hpp in Headers */,
+				04F464B826C510E1007CEEAB /* weight_base.hpp in Headers */,
+				04F464E526C510E1007CEEAB /* file.hpp in Headers */,
+				04F464E426C510E1007CEEAB /* runtime_header.hpp in Headers */,
+				04F464E126C510E1007CEEAB /* state_machine_importer.hpp in Headers */,
+				04F4650D26C510E1007CEEAB /* keyframe_color.hpp in Headers */,
+				04F4655226C510E1007CEEAB /* transform_component.hpp in Headers */,
+				04F464C126C510E1007CEEAB /* drawable_base.hpp in Headers */,
+				04F464AA26C510E1007CEEAB /* points_path_base.hpp in Headers */,
+				04F4652226C510E1007CEEAB /* trim_path.hpp in Headers */,
+				04F4647926C510E1007CEEAB /* world_transform_component_base.hpp in Headers */,
+				04F4648126C510E1007CEEAB /* blend_state_base.hpp in Headers */,
+				04F4652626C510E1007CEEAB /* stroke_effect.hpp in Headers */,
+				04F4650C26C510E1007CEEAB /* loop.hpp in Headers */,
+				04F4651826C510E1007CEEAB /* straight_vertex.hpp in Headers */,
+				04F4649B26C510E1007CEEAB /* state_machine_trigger_base.hpp in Headers */,
+				04F464E026C510E1007CEEAB /* artboard_importer.hpp in Headers */,
+				04F464F626C510E1007CEEAB /* state_machine_layer.hpp in Headers */,
 				C9C73EE224FC478900EF9516 /* RiveRuntime.h in Headers */,
-				04F461FA26C4030D007CEEAB /* component_base.hpp in Headers */,
-				04F4622826C4030D007CEEAB /* state_transition.hpp in Headers */,
-				04F461BB26C4030D007CEEAB /* distance_constraint_base.hpp in Headers */,
-				04F461E826C4030D007CEEAB /* gradient_stop_base.hpp in Headers */,
-				04F4622D26C4030D007CEEAB /* transition_number_condition.hpp in Headers */,
-				04F461D626C4030D007CEEAB /* blend_animation_direct_base.hpp in Headers */,
-				04F461DE26C4030D007CEEAB /* state_machine_trigger_base.hpp in Headers */,
-				04F4628326C4030D007CEEAB /* tendon.hpp in Headers */,
-				04F4621126C4030D007CEEAB /* transform_constraint.hpp in Headers */,
-				04F461DA26C4030D007CEEAB /* any_state_base.hpp in Headers */,
-				04F4627826C4030D007CEEAB /* color.hpp in Headers */,
-				04F461BD26C4030D007CEEAB /* draw_rules_base.hpp in Headers */,
-				04F4624526C4030D007CEEAB /* keyframe_double.hpp in Headers */,
-				04F461DC26C4030D007CEEAB /* state_machine_input_base.hpp in Headers */,
-				04F4622026C4030D007CEEAB /* runtime_header.hpp in Headers */,
-				04F461D326C4030D007CEEAB /* keyframe_double_base.hpp in Headers */,
-				04F461CE26C4030D007CEEAB /* blend_animation_1d_base.hpp in Headers */,
-				04F4625D26C4030D007CEEAB /* trim_path.hpp in Headers */,
-				04F4626D26C4030D007CEEAB /* polygon.hpp in Headers */,
+				04F464F326C510E1007CEEAB /* animation.hpp in Headers */,
+				04F4649526C510E1007CEEAB /* transition_trigger_condition_base.hpp in Headers */,
+				04F4649326C510E1007CEEAB /* blend_animation_direct_base.hpp in Headers */,
+				04F464F426C510E1007CEEAB /* keyframe.hpp in Headers */,
+				04F4649F26C510E1007CEEAB /* stroke_base.hpp in Headers */,
+				04F4653B26C510E1007CEEAB /* mat2d.hpp in Headers */,
+				04F464C026C510E1007CEEAB /* backboard_base.hpp in Headers */,
+				04F464FF26C510E1007CEEAB /* state_machine.hpp in Headers */,
+				04F4654526C510E1007CEEAB /* artboard.hpp in Headers */,
+				04F464FB26C510E1007CEEAB /* blend_state_1d.hpp in Headers */,
+				04F4653E26C510E1007CEEAB /* transform_components.hpp in Headers */,
+				04F464CE26C510E1007CEEAB /* constraint.hpp in Headers */,
+				04F464CF26C510E1007CEEAB /* rotation_constraint.hpp in Headers */,
+				04F4652D26C510E1007CEEAB /* metrics_path.hpp in Headers */,
+				04F4648926C510E1007CEEAB /* state_machine_layer_base.hpp in Headers */,
+				04F464F926C510E1007CEEAB /* blend_state_instance.hpp in Headers */,
+				04F4653126C510E1007CEEAB /* path.hpp in Headers */,
+				04F464D526C510E1007CEEAB /* distance_constraint.hpp in Headers */,
+				04F4655026C510E1007CEEAB /* draw_rules.hpp in Headers */,
+				04F464F526C510E1007CEEAB /* blend_state.hpp in Headers */,
+				04F4649026C510E1007CEEAB /* keyframe_double_base.hpp in Headers */,
+				04F464FC26C510E1007CEEAB /* state_instance.hpp in Headers */,
+				04F464B326C510E1007CEEAB /* cubic_detached_vertex_base.hpp in Headers */,
+				04F4652026C510E1007CEEAB /* fill.hpp in Headers */,
+				04F4650026C510E1007CEEAB /* blend_state_1d_instance.hpp in Headers */,
+				04F4648D26C510E1007CEEAB /* transition_value_condition_base.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2089,8 +2180,10 @@
 				C9A9DA1F265C51100005DB1F /* blend_state_transition.cpp in Sources */,
 				046FB7F5264EAA60000129B1 /* RiveSMIInput.mm in Sources */,
 				C9A9DA19265C51100005DB1F /* blend_animation_direct.cpp in Sources */,
+				04F4656026C514A4007CEEAB /* scale_constraint_base.cpp in Sources */,
 				C9A9DA5D265C51A40005DB1F /* draw_target_base.cpp in Sources */,
 				C9A9DA6B265C51A40005DB1F /* linear_animation_base.cpp in Sources */,
+				04F4656426C514B7007CEEAB /* keyframe_bool.cpp in Sources */,
 				C9A9DA7D265C51A40005DB1F /* cubic_detached_vertex_base.cpp in Sources */,
 				C9C7416624FC4F0500EF9516 /* dependency_sorter.cpp in Sources */,
 				C9601FAF251004950032AA07 /* trim_path.cpp in Sources */,
@@ -2121,19 +2214,23 @@
 				C9C7415B24FC4F0500EF9516 /* path_vertex.cpp in Sources */,
 				C9C7414B24FC4F0500EF9516 /* solid_color.cpp in Sources */,
 				C9A9DA85265C51A40005DB1F /* shape_base.cpp in Sources */,
+				04F4655626C51416007CEEAB /* translation_constraint.cpp in Sources */,
 				C9C741F524FC510200EF9516 /* Rive.mm in Sources */,
 				C9BD3908263B5E7600696C37 /* state_transition_importer.cpp in Sources */,
 				0450446E26B3F82D007B25CA /* distance_constraint.cpp in Sources */,
 				C9A9DA5E265C51A40005DB1F /* backboard_base.cpp in Sources */,
 				C9C7415724FC4F0500EF9516 /* cubic_vertex.cpp in Sources */,
 				04F1C92426A84B5200CEE6BE /* constraint.cpp in Sources */,
+				04F4656226C514AC007CEEAB /* keyframe_bool_base.cpp in Sources */,
 				C9A9DA61265C51A40005DB1F /* state_machine_base.cpp in Sources */,
 				C9BD391D263B5E9000696C37 /* state_machine_layer.cpp in Sources */,
 				C9C7414E24FC4F0500EF9516 /* fill.cpp in Sources */,
+				04F4655A26C51422007CEEAB /* world_transform_component.cpp in Sources */,
 				C9BD391F263B5E9000696C37 /* transition_condition.cpp in Sources */,
 				046FB7F8264EAA60000129B1 /* RiveStateMachineInstance.mm in Sources */,
 				C9601FB3251004950032AA07 /* shape_paint.cpp in Sources */,
 				C9BD391A263B5E9000696C37 /* transition_number_condition.cpp in Sources */,
+				04F4655726C51416007CEEAB /* scale_constraint.cpp in Sources */,
 				C9C7416124FC4F0500EF9516 /* ellipse.cpp in Sources */,
 				046FB7FF264EAA61000129B1 /* RiveFile.mm in Sources */,
 				C9C7415124FC4F0500EF9516 /* shape_paint_mutator.cpp in Sources */,
@@ -2195,6 +2292,8 @@
 				04F1C92626A84B5200CEE6BE /* targeted_constraint.cpp in Sources */,
 				04F1C93226A84B8700CEE6BE /* blend_state_1d_base.cpp in Sources */,
 				C9C7414824FC4F0500EF9516 /* keyed_property.cpp in Sources */,
+				04F4655E26C514A4007CEEAB /* rotation_constraint_base.cpp in Sources */,
+				04F4655F26C514A4007CEEAB /* translation_constraint_base.cpp in Sources */,
 				046FB7F6264EAA60000129B1 /* RiveStateMachineInput.mm in Sources */,
 				C9A9DA65265C51A40005DB1F /* keyframe_double_base.cpp in Sources */,
 				C9A9DA21265C51100005DB1F /* blend_animation.cpp in Sources */,
@@ -2235,6 +2334,7 @@
 				C9A9DA62265C51A40005DB1F /* exit_state_base.cpp in Sources */,
 				C9A9DA1D265C51100005DB1F /* blend_state_direct.cpp in Sources */,
 				C9A9DA74265C51A40005DB1F /* straight_vertex_base.cpp in Sources */,
+				04F4655826C51416007CEEAB /* rotation_constraint.cpp in Sources */,
 				C9A9DA71265C51A40005DB1F /* keyed_property_base.cpp in Sources */,
 				C9A9DA86265C51A40005DB1F /* cubic_asymmetric_vertex_base.cpp in Sources */,
 				C9C7416224FC4F0500EF9516 /* clipping_shape.cpp in Sources */,

--- a/RiveRuntime.xcodeproj/project.pbxproj
+++ b/RiveRuntime.xcodeproj/project.pbxproj
@@ -7,11 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0450446426B3F74A007B25CA /* transform_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0450446226B3F74A007B25CA /* transform_constraint.hpp */; };
-		0450446526B3F74A007B25CA /* distance_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0450446326B3F74A007B25CA /* distance_constraint.hpp */; };
-		0450446826B3F7A5007B25CA /* distance_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0450446626B3F7A5007B25CA /* distance_constraint_base.hpp */; };
-		0450446926B3F7A5007B25CA /* transform_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0450446726B3F7A5007B25CA /* transform_constraint_base.hpp */; };
-		0450446B26B3F7C1007B25CA /* transform_space.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0450446A26B3F7C1007B25CA /* transform_space.hpp */; };
 		0450446E26B3F82D007B25CA /* distance_constraint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0450446C26B3F82D007B25CA /* distance_constraint.cpp */; };
 		0450446F26B3F82D007B25CA /* transform_constraint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0450446D26B3F82D007B25CA /* transform_constraint.cpp */; };
 		0450447226B3F83C007B25CA /* distance_constraint_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0450447026B3F83C007B25CA /* distance_constraint_base.cpp */; };
@@ -57,7 +52,6 @@
 		04BE5430264D1F4100427B39 /* LayerState.h in Headers */ = {isa = PBXBuildFile; fileRef = 04BE542F264D1F4100427B39 /* LayerState.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		04BE5434264D267900427B39 /* LayerState.mm in Sources */ = {isa = PBXBuildFile; fileRef = 04BE5431264D243D00427B39 /* LayerState.mm */; };
 		04BE5436264D2A7500427B39 /* RivePrivateHeaders.h in Headers */ = {isa = PBXBuildFile; fileRef = 04BE5435264D2A7500427B39 /* RivePrivateHeaders.h */; };
-		04C8D517265BFE3500508ACB /* runtime_header.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740EF24FC4F0400EF9516 /* runtime_header.hpp */; };
 		04F1C92426A84B5200CEE6BE /* constraint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F1C92126A84B5200CEE6BE /* constraint.cpp */; };
 		04F1C92526A84B5200CEE6BE /* ik_constraint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F1C92226A84B5200CEE6BE /* ik_constraint.cpp */; };
 		04F1C92626A84B5200CEE6BE /* targeted_constraint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F1C92326A84B5200CEE6BE /* targeted_constraint.cpp */; };
@@ -67,83 +61,236 @@
 		04F1C93126A84B8700CEE6BE /* blend_state_transition_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F1C92C26A84B8700CEE6BE /* blend_state_transition_base.cpp */; };
 		04F1C93226A84B8700CEE6BE /* blend_state_1d_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F1C92D26A84B8700CEE6BE /* blend_state_1d_base.cpp */; };
 		04F1C93326A84B8700CEE6BE /* blend_state_direct_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04F1C92E26A84B8700CEE6BE /* blend_state_direct_base.cpp */; };
-		04F1C93826A84BB400CEE6BE /* targeted_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F1C93526A84BB400CEE6BE /* targeted_constraint.hpp */; };
-		04F1C93926A84BB400CEE6BE /* constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F1C93626A84BB400CEE6BE /* constraint.hpp */; };
-		04F1C93A26A84BB400CEE6BE /* ik_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F1C93726A84BB400CEE6BE /* ik_constraint.hpp */; };
-		04F1C93F26A84BD900CEE6BE /* constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F1C93C26A84BD900CEE6BE /* constraint_base.hpp */; };
-		04F1C94026A84BD900CEE6BE /* targeted_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F1C93D26A84BD900CEE6BE /* targeted_constraint_base.hpp */; };
-		04F1C94126A84BD900CEE6BE /* ik_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F1C93E26A84BD900CEE6BE /* ik_constraint_base.hpp */; };
+		04F461B426C4030D007CEEAB /* core_registry.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460CC26C4030C007CEEAB /* core_registry.hpp */; };
+		04F461B526C4030D007CEEAB /* node_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460CD26C4030C007CEEAB /* node_base.hpp */; };
+		04F461B626C4030D007CEEAB /* transform_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460CE26C4030C007CEEAB /* transform_component_base.hpp */; };
+		04F461B726C4030D007CEEAB /* constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D026C4030C007CEEAB /* constraint_base.hpp */; };
+		04F461B826C4030D007CEEAB /* targeted_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D126C4030C007CEEAB /* targeted_constraint_base.hpp */; };
+		04F461B926C4030D007CEEAB /* ik_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D226C4030C007CEEAB /* ik_constraint_base.hpp */; };
+		04F461BA26C4030D007CEEAB /* transform_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D326C4030C007CEEAB /* transform_constraint_base.hpp */; };
+		04F461BB26C4030D007CEEAB /* distance_constraint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D426C4030C007CEEAB /* distance_constraint_base.hpp */; };
+		04F461BC26C4030D007CEEAB /* artboard_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D526C4030C007CEEAB /* artboard_base.hpp */; };
+		04F461BD26C4030D007CEEAB /* draw_rules_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D626C4030C007CEEAB /* draw_rules_base.hpp */; };
+		04F461BE26C4030D007CEEAB /* blend_animation_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D826C4030C007CEEAB /* blend_animation_base.hpp */; };
+		04F461BF26C4030D007CEEAB /* keyframe_color_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460D926C4030C007CEEAB /* keyframe_color_base.hpp */; };
+		04F461C026C4030D007CEEAB /* keyed_property_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460DA26C4030C007CEEAB /* keyed_property_base.hpp */; };
+		04F461C126C4030D007CEEAB /* keyframe_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460DB26C4030C007CEEAB /* keyframe_base.hpp */; };
+		04F461C226C4030D007CEEAB /* animation_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460DC26C4030C007CEEAB /* animation_state_base.hpp */; };
+		04F461C326C4030D007CEEAB /* animation_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460DD26C4030C007CEEAB /* animation_base.hpp */; };
+		04F461C426C4030D007CEEAB /* blend_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460DE26C4030C007CEEAB /* blend_state_base.hpp */; };
+		04F461C526C4030D007CEEAB /* transition_number_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460DF26C4030C007CEEAB /* transition_number_condition_base.hpp */; };
+		04F461C626C4030D007CEEAB /* cubic_interpolator_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E026C4030C007CEEAB /* cubic_interpolator_base.hpp */; };
+		04F461C726C4030D007CEEAB /* linear_animation_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E126C4030C007CEEAB /* linear_animation_base.hpp */; };
+		04F461C826C4030D007CEEAB /* entry_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E226C4030C007CEEAB /* entry_state_base.hpp */; };
+		04F461C926C4030D007CEEAB /* layer_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E326C4030C007CEEAB /* layer_state_base.hpp */; };
+		04F461CA26C4030D007CEEAB /* state_machine_layer_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E426C4030C007CEEAB /* state_machine_layer_component_base.hpp */; };
+		04F461CB26C4030D007CEEAB /* blend_state_direct_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E526C4030C007CEEAB /* blend_state_direct_base.hpp */; };
+		04F461CC26C4030D007CEEAB /* state_machine_layer_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E626C4030C007CEEAB /* state_machine_layer_base.hpp */; };
+		04F461CD26C4030D007CEEAB /* keyframe_id_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E726C4030C007CEEAB /* keyframe_id_base.hpp */; };
+		04F461CE26C4030D007CEEAB /* blend_animation_1d_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E826C4030C007CEEAB /* blend_animation_1d_base.hpp */; };
+		04F461CF26C4030D007CEEAB /* keyed_object_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460E926C4030C007CEEAB /* keyed_object_base.hpp */; };
+		04F461D026C4030D007CEEAB /* transition_value_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460EA26C4030C007CEEAB /* transition_value_condition_base.hpp */; };
+		04F461D126C4030D007CEEAB /* state_machine_number_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460EB26C4030C007CEEAB /* state_machine_number_base.hpp */; };
+		04F461D226C4030D007CEEAB /* state_transition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460EC26C4030C007CEEAB /* state_transition_base.hpp */; };
+		04F461D326C4030D007CEEAB /* keyframe_double_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460ED26C4030C007CEEAB /* keyframe_double_base.hpp */; };
+		04F461D426C4030D007CEEAB /* state_machine_bool_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460EE26C4030C007CEEAB /* state_machine_bool_base.hpp */; };
+		04F461D526C4030D007CEEAB /* blend_state_transition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460EF26C4030C007CEEAB /* blend_state_transition_base.hpp */; };
+		04F461D626C4030D007CEEAB /* blend_animation_direct_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F026C4030C007CEEAB /* blend_animation_direct_base.hpp */; };
+		04F461D726C4030D007CEEAB /* transition_bool_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F126C4030C007CEEAB /* transition_bool_condition_base.hpp */; };
+		04F461D826C4030D007CEEAB /* transition_trigger_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F226C4030C007CEEAB /* transition_trigger_condition_base.hpp */; };
+		04F461D926C4030D007CEEAB /* state_machine_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F326C4030C007CEEAB /* state_machine_component_base.hpp */; };
+		04F461DA26C4030D007CEEAB /* any_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F426C4030C007CEEAB /* any_state_base.hpp */; };
+		04F461DB26C4030D007CEEAB /* transition_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F526C4030C007CEEAB /* transition_condition_base.hpp */; };
+		04F461DC26C4030D007CEEAB /* state_machine_input_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F626C4030C007CEEAB /* state_machine_input_base.hpp */; };
+		04F461DD26C4030D007CEEAB /* blend_state_1d_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F726C4030D007CEEAB /* blend_state_1d_base.hpp */; };
+		04F461DE26C4030D007CEEAB /* state_machine_trigger_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F826C4030D007CEEAB /* state_machine_trigger_base.hpp */; };
+		04F461DF26C4030D007CEEAB /* state_machine_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460F926C4030D007CEEAB /* state_machine_base.hpp */; };
+		04F461E026C4030D007CEEAB /* exit_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460FA26C4030D007CEEAB /* exit_state_base.hpp */; };
+		04F461E126C4030D007CEEAB /* linear_gradient_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460FD26C4030D007CEEAB /* linear_gradient_base.hpp */; };
+		04F461E226C4030D007CEEAB /* stroke_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460FE26C4030D007CEEAB /* stroke_base.hpp */; };
+		04F461E326C4030D007CEEAB /* fill_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F460FF26C4030D007CEEAB /* fill_base.hpp */; };
+		04F461E426C4030D007CEEAB /* shape_paint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610026C4030D007CEEAB /* shape_paint_base.hpp */; };
+		04F461E526C4030D007CEEAB /* solid_color_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610126C4030D007CEEAB /* solid_color_base.hpp */; };
+		04F461E626C4030D007CEEAB /* trim_path_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610226C4030D007CEEAB /* trim_path_base.hpp */; };
+		04F461E726C4030D007CEEAB /* radial_gradient_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610326C4030D007CEEAB /* radial_gradient_base.hpp */; };
+		04F461E826C4030D007CEEAB /* gradient_stop_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610426C4030D007CEEAB /* gradient_stop_base.hpp */; };
+		04F461E926C4030D007CEEAB /* parametric_path_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610526C4030D007CEEAB /* parametric_path_base.hpp */; };
+		04F461EA26C4030D007CEEAB /* cubic_asymmetric_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610626C4030D007CEEAB /* cubic_asymmetric_vertex_base.hpp */; };
+		04F461EB26C4030D007CEEAB /* cubic_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610726C4030D007CEEAB /* cubic_vertex_base.hpp */; };
+		04F461EC26C4030D007CEEAB /* ellipse_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610826C4030D007CEEAB /* ellipse_base.hpp */; };
+		04F461ED26C4030D007CEEAB /* points_path_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610926C4030D007CEEAB /* points_path_base.hpp */; };
+		04F461EE26C4030D007CEEAB /* triangle_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610A26C4030D007CEEAB /* triangle_base.hpp */; };
+		04F461EF26C4030D007CEEAB /* shape_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610B26C4030D007CEEAB /* shape_base.hpp */; };
+		04F461F026C4030D007CEEAB /* rectangle_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610C26C4030D007CEEAB /* rectangle_base.hpp */; };
+		04F461F126C4030D007CEEAB /* cubic_mirrored_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610D26C4030D007CEEAB /* cubic_mirrored_vertex_base.hpp */; };
+		04F461F226C4030D007CEEAB /* star_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610E26C4030D007CEEAB /* star_base.hpp */; };
+		04F461F326C4030D007CEEAB /* straight_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4610F26C4030D007CEEAB /* straight_vertex_base.hpp */; };
+		04F461F426C4030D007CEEAB /* path_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611026C4030D007CEEAB /* path_base.hpp */; };
+		04F461F526C4030D007CEEAB /* polygon_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611126C4030D007CEEAB /* polygon_base.hpp */; };
+		04F461F626C4030D007CEEAB /* cubic_detached_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611226C4030D007CEEAB /* cubic_detached_vertex_base.hpp */; };
+		04F461F726C4030D007CEEAB /* clipping_shape_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611326C4030D007CEEAB /* clipping_shape_base.hpp */; };
+		04F461F826C4030D007CEEAB /* path_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611426C4030D007CEEAB /* path_vertex_base.hpp */; };
+		04F461F926C4030D007CEEAB /* container_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611526C4030D007CEEAB /* container_component_base.hpp */; };
+		04F461FA26C4030D007CEEAB /* component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611626C4030D007CEEAB /* component_base.hpp */; };
+		04F461FB26C4030D007CEEAB /* weight_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611826C4030D007CEEAB /* weight_base.hpp */; };
+		04F461FC26C4030D007CEEAB /* root_bone_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611926C4030D007CEEAB /* root_bone_base.hpp */; };
+		04F461FD26C4030D007CEEAB /* cubic_weight_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611A26C4030D007CEEAB /* cubic_weight_base.hpp */; };
+		04F461FE26C4030D007CEEAB /* bone_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611B26C4030D007CEEAB /* bone_base.hpp */; };
+		04F461FF26C4030D007CEEAB /* skin_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611C26C4030D007CEEAB /* skin_base.hpp */; };
+		04F4620026C4030D007CEEAB /* tendon_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611D26C4030D007CEEAB /* tendon_base.hpp */; };
+		04F4620126C4030D007CEEAB /* skeletal_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611E26C4030D007CEEAB /* skeletal_component_base.hpp */; };
+		04F4620226C4030D007CEEAB /* draw_target_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4611F26C4030D007CEEAB /* draw_target_base.hpp */; };
+		04F4620326C4030D007CEEAB /* backboard_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612026C4030D007CEEAB /* backboard_base.hpp */; };
+		04F4620426C4030D007CEEAB /* drawable_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612126C4030D007CEEAB /* drawable_base.hpp */; };
+		04F4620526C4030D007CEEAB /* backboard.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612226C4030D007CEEAB /* backboard.hpp */; };
+		04F4620626C4030D007CEEAB /* reader.h in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612426C4030D007CEEAB /* reader.h */; };
+		04F4620726C4030D007CEEAB /* core_color_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612626C4030D007CEEAB /* core_color_type.hpp */; };
+		04F4620826C4030D007CEEAB /* core_uint_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612726C4030D007CEEAB /* core_uint_type.hpp */; };
+		04F4620926C4030D007CEEAB /* core_double_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612826C4030D007CEEAB /* core_double_type.hpp */; };
+		04F4620A26C4030D007CEEAB /* core_string_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612926C4030D007CEEAB /* core_string_type.hpp */; };
+		04F4620B26C4030D007CEEAB /* core_bool_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612A26C4030D007CEEAB /* core_bool_type.hpp */; };
+		04F4620C26C4030D007CEEAB /* binary_reader.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612B26C4030D007CEEAB /* binary_reader.hpp */; };
+		04F4620D26C4030D007CEEAB /* status_code.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612C26C4030D007CEEAB /* status_code.hpp */; };
+		04F4620E26C4030D007CEEAB /* targeted_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612E26C4030D007CEEAB /* targeted_constraint.hpp */; };
+		04F4620F26C4030D007CEEAB /* constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4612F26C4030D007CEEAB /* constraint.hpp */; };
+		04F4621026C4030D007CEEAB /* ik_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613026C4030D007CEEAB /* ik_constraint.hpp */; };
+		04F4621126C4030D007CEEAB /* transform_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613126C4030D007CEEAB /* transform_constraint.hpp */; };
+		04F4621226C4030D007CEEAB /* distance_constraint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613226C4030D007CEEAB /* distance_constraint.hpp */; };
+		04F4621326C4030D007CEEAB /* component_dirt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613326C4030D007CEEAB /* component_dirt.hpp */; };
+		04F4621426C4030D007CEEAB /* renderer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613426C4030D007CEEAB /* renderer.hpp */; };
+		04F4621526C4030D007CEEAB /* draw_target_placement.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613526C4030D007CEEAB /* draw_target_placement.hpp */; };
+		04F4621626C4030D007CEEAB /* state_transition_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613726C4030D007CEEAB /* state_transition_importer.hpp */; };
+		04F4621726C4030D007CEEAB /* state_machine_layer_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613826C4030D007CEEAB /* state_machine_layer_importer.hpp */; };
+		04F4621826C4030D007CEEAB /* keyed_property_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613926C4030D007CEEAB /* keyed_property_importer.hpp */; };
+		04F4621926C4030D007CEEAB /* keyed_object_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613A26C4030D007CEEAB /* keyed_object_importer.hpp */; };
+		04F4621A26C4030D007CEEAB /* linear_animation_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613B26C4030D007CEEAB /* linear_animation_importer.hpp */; };
+		04F4621B26C4030D007CEEAB /* import_stack.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613C26C4030D007CEEAB /* import_stack.hpp */; };
+		04F4621C26C4030D007CEEAB /* layer_state_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613D26C4030D007CEEAB /* layer_state_importer.hpp */; };
+		04F4621D26C4030D007CEEAB /* artboard_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613E26C4030D007CEEAB /* artboard_importer.hpp */; };
+		04F4621E26C4030D007CEEAB /* state_machine_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4613F26C4030D007CEEAB /* state_machine_importer.hpp */; };
+		04F4621F26C4030D007CEEAB /* draw_target.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614026C4030D007CEEAB /* draw_target.hpp */; };
+		04F4622026C4030D007CEEAB /* runtime_header.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614126C4030D007CEEAB /* runtime_header.hpp */; };
+		04F4622126C4030D007CEEAB /* file.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614226C4030D007CEEAB /* file.hpp */; };
+		04F4622226C4030D007CEEAB /* container_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614326C4030D007CEEAB /* container_component.hpp */; };
+		04F4622326C4030D007CEEAB /* transition_bool_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614526C4030D007CEEAB /* transition_bool_condition.hpp */; };
+		04F4622426C4030D007CEEAB /* cubic_interpolator.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614626C4030D007CEEAB /* cubic_interpolator.hpp */; };
+		04F4622526C4030D007CEEAB /* keyed_property.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614726C4030D007CEEAB /* keyed_property.hpp */; };
+		04F4622626C4030D007CEEAB /* state_machine_input.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614826C4030D007CEEAB /* state_machine_input.hpp */; };
+		04F4622726C4030D007CEEAB /* layer_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614926C4030D007CEEAB /* layer_state.hpp */; };
+		04F4622826C4030D007CEEAB /* state_transition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614A26C4030D007CEEAB /* state_transition.hpp */; };
+		04F4622926C4030D007CEEAB /* system_state_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614B26C4030D007CEEAB /* system_state_instance.hpp */; };
+		04F4622A26C4030D007CEEAB /* state_machine_trigger.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614C26C4030D007CEEAB /* state_machine_trigger.hpp */; };
+		04F4622B26C4030D007CEEAB /* keyframe_id.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614D26C4030D007CEEAB /* keyframe_id.hpp */; };
+		04F4622C26C4030D007CEEAB /* blend_state_transition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614E26C4030D007CEEAB /* blend_state_transition.hpp */; };
+		04F4622D26C4030D007CEEAB /* transition_number_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4614F26C4030D007CEEAB /* transition_number_condition.hpp */; };
+		04F4622E26C4030D007CEEAB /* state_machine_number.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615026C4030D007CEEAB /* state_machine_number.hpp */; };
+		04F4622F26C4030D007CEEAB /* animation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615126C4030D007CEEAB /* animation.hpp */; };
+		04F4623026C4030D007CEEAB /* keyframe.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615226C4030D007CEEAB /* keyframe.hpp */; };
+		04F4623126C4030D007CEEAB /* blend_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615326C4030D007CEEAB /* blend_state.hpp */; };
+		04F4623226C4030D007CEEAB /* state_machine_layer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615426C4030D007CEEAB /* state_machine_layer.hpp */; };
+		04F4623326C4030D007CEEAB /* blend_animation_1d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615526C4030D007CEEAB /* blend_animation_1d.hpp */; };
+		04F4623426C4030D007CEEAB /* state_machine_layer_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615626C4030D007CEEAB /* state_machine_layer_component.hpp */; };
+		04F4623526C4030D007CEEAB /* blend_state_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615726C4030D007CEEAB /* blend_state_instance.hpp */; };
+		04F4623626C4030D007CEEAB /* state_machine_bool.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615826C4030D007CEEAB /* state_machine_bool.hpp */; };
+		04F4623726C4030D007CEEAB /* blend_state_1d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615926C4030D007CEEAB /* blend_state_1d.hpp */; };
+		04F4623826C4030D007CEEAB /* state_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615A26C4030D007CEEAB /* state_instance.hpp */; };
+		04F4623926C4030D007CEEAB /* keyed_object.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615B26C4030D007CEEAB /* keyed_object.hpp */; };
+		04F4623A26C4030D007CEEAB /* state_machine_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615C26C4030D007CEEAB /* state_machine_component.hpp */; };
+		04F4623B26C4030D007CEEAB /* state_machine.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615D26C4030D007CEEAB /* state_machine.hpp */; };
+		04F4623C26C4030D007CEEAB /* blend_state_1d_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615E26C4030D007CEEAB /* blend_state_1d_instance.hpp */; };
+		04F4623D26C4030D007CEEAB /* state_machine_input_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4615F26C4030D007CEEAB /* state_machine_input_instance.hpp */; };
+		04F4623E26C4030D007CEEAB /* transition_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616026C4030D007CEEAB /* transition_condition.hpp */; };
+		04F4623F26C4030D007CEEAB /* transition_value_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616126C4030D007CEEAB /* transition_value_condition.hpp */; };
+		04F4624026C4030D007CEEAB /* animation_state_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616226C4030D007CEEAB /* animation_state_instance.hpp */; };
+		04F4624126C4030D007CEEAB /* linear_animation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616326C4030D007CEEAB /* linear_animation.hpp */; };
+		04F4624226C4030D007CEEAB /* linear_animation_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616426C4030D007CEEAB /* linear_animation_instance.hpp */; };
+		04F4624326C4030D007CEEAB /* transition_condition_op.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616526C4030D007CEEAB /* transition_condition_op.hpp */; };
+		04F4624426C4030D007CEEAB /* blend_state_direct_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616626C4030D007CEEAB /* blend_state_direct_instance.hpp */; };
+		04F4624526C4030D007CEEAB /* keyframe_double.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616726C4030D007CEEAB /* keyframe_double.hpp */; };
+		04F4624626C4030D007CEEAB /* blend_animation_direct.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616826C4030D007CEEAB /* blend_animation_direct.hpp */; };
+		04F4624726C4030D007CEEAB /* loop.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616926C4030D007CEEAB /* loop.hpp */; };
+		04F4624826C4030D007CEEAB /* keyframe_color.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616A26C4030D007CEEAB /* keyframe_color.hpp */; };
+		04F4624926C4030D007CEEAB /* entry_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616B26C4030D007CEEAB /* entry_state.hpp */; };
+		04F4624A26C4030D007CEEAB /* blend_animation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616C26C4030D007CEEAB /* blend_animation.hpp */; };
+		04F4624B26C4030D007CEEAB /* state_machine_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616D26C4030D007CEEAB /* state_machine_instance.hpp */; };
+		04F4624C26C4030D007CEEAB /* state_transition_flags.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616E26C4030D007CEEAB /* state_transition_flags.hpp */; };
+		04F4624D26C4030D007CEEAB /* exit_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4616F26C4030D007CEEAB /* exit_state.hpp */; };
+		04F4624E26C4030D007CEEAB /* any_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617026C4030D007CEEAB /* any_state.hpp */; };
+		04F4624F26C4030D007CEEAB /* animation_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617126C4030D007CEEAB /* animation_state.hpp */; };
+		04F4625026C4030D007CEEAB /* blend_state_direct.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617226C4030D007CEEAB /* blend_state_direct.hpp */; };
+		04F4625126C4030D007CEEAB /* transition_trigger_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617326C4030D007CEEAB /* transition_trigger_condition.hpp */; };
+		04F4625226C4030D007CEEAB /* transform_space.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617426C4030D007CEEAB /* transform_space.hpp */; };
+		04F4625326C4030D007CEEAB /* straight_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617626C4030D007CEEAB /* straight_vertex.hpp */; };
+		04F4625426C4030D007CEEAB /* stroke_cap.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617826C4030D007CEEAB /* stroke_cap.hpp */; };
+		04F4625526C4030D007CEEAB /* gradient_stop.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617926C4030D007CEEAB /* gradient_stop.hpp */; };
+		04F4625626C4030D007CEEAB /* stroke.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617A26C4030D007CEEAB /* stroke.hpp */; };
+		04F4625726C4030D007CEEAB /* shape_paint_mutator.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617B26C4030D007CEEAB /* shape_paint_mutator.hpp */; };
+		04F4625826C4030D007CEEAB /* blend_mode.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617C26C4030D007CEEAB /* blend_mode.hpp */; };
+		04F4625926C4030D007CEEAB /* shape_paint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617D26C4030D007CEEAB /* shape_paint.hpp */; };
+		04F4625A26C4030D007CEEAB /* stroke_join.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617E26C4030D007CEEAB /* stroke_join.hpp */; };
+		04F4625B26C4030D007CEEAB /* fill.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4617F26C4030D007CEEAB /* fill.hpp */; };
+		04F4625C26C4030D007CEEAB /* radial_gradient.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618026C4030D007CEEAB /* radial_gradient.hpp */; };
+		04F4625D26C4030D007CEEAB /* trim_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618126C4030D007CEEAB /* trim_path.hpp */; };
+		04F4625E26C4030D007CEEAB /* color.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618226C4030D007CEEAB /* color.hpp */; };
+		04F4625F26C4030D007CEEAB /* solid_color.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618326C4030D007CEEAB /* solid_color.hpp */; };
+		04F4626026C4030D007CEEAB /* linear_gradient.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618426C4030D007CEEAB /* linear_gradient.hpp */; };
+		04F4626126C4030D007CEEAB /* stroke_effect.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618526C4030D007CEEAB /* stroke_effect.hpp */; };
+		04F4626226C4030D007CEEAB /* path_composer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618626C4030D007CEEAB /* path_composer.hpp */; };
+		04F4626326C4030D007CEEAB /* shape_paint_container.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618726C4030D007CEEAB /* shape_paint_container.hpp */; };
+		04F4626426C4030D007CEEAB /* cubic_mirrored_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618826C4030D007CEEAB /* cubic_mirrored_vertex.hpp */; };
+		04F4626526C4030D007CEEAB /* path_space.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618926C4030D007CEEAB /* path_space.hpp */; };
+		04F4626626C4030D007CEEAB /* ellipse.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618A26C4030D007CEEAB /* ellipse.hpp */; };
+		04F4626726C4030D007CEEAB /* clipping_shape.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618B26C4030D007CEEAB /* clipping_shape.hpp */; };
+		04F4626826C4030D007CEEAB /* metrics_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618C26C4030D007CEEAB /* metrics_path.hpp */; };
+		04F4626926C4030D007CEEAB /* cubic_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618D26C4030D007CEEAB /* cubic_vertex.hpp */; };
+		04F4626A26C4030D007CEEAB /* shape.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618E26C4030D007CEEAB /* shape.hpp */; };
+		04F4626B26C4030D007CEEAB /* triangle.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4618F26C4030D007CEEAB /* triangle.hpp */; };
+		04F4626C26C4030D007CEEAB /* path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619026C4030D007CEEAB /* path.hpp */; };
+		04F4626D26C4030D007CEEAB /* polygon.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619126C4030D007CEEAB /* polygon.hpp */; };
+		04F4626E26C4030D007CEEAB /* path_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619226C4030D007CEEAB /* path_vertex.hpp */; };
+		04F4626F26C4030D007CEEAB /* parametric_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619326C4030D007CEEAB /* parametric_path.hpp */; };
+		04F4627026C4030D007CEEAB /* rectangle.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619426C4030D007CEEAB /* rectangle.hpp */; };
+		04F4627126C4030D007CEEAB /* points_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619526C4030D007CEEAB /* points_path.hpp */; };
+		04F4627226C4030D007CEEAB /* star.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619626C4030D007CEEAB /* star.hpp */; };
+		04F4627326C4030D007CEEAB /* cubic_asymmetric_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619726C4030D007CEEAB /* cubic_asymmetric_vertex.hpp */; };
+		04F4627426C4030D007CEEAB /* cubic_detached_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619826C4030D007CEEAB /* cubic_detached_vertex.hpp */; };
+		04F4627526C4030D007CEEAB /* vec2d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619A26C4030D007CEEAB /* vec2d.hpp */; };
+		04F4627626C4030D007CEEAB /* mat2d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619B26C4030D007CEEAB /* mat2d.hpp */; };
+		04F4627726C4030D007CEEAB /* aabb.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619C26C4030D007CEEAB /* aabb.hpp */; };
+		04F4627826C4030D007CEEAB /* color.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619D26C4030D007CEEAB /* color.hpp */; };
+		04F4627926C4030D007CEEAB /* transform_components.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619E26C4030D007CEEAB /* transform_components.hpp */; };
+		04F4627A26C4030D007CEEAB /* circle_constant.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F4619F26C4030D007CEEAB /* circle_constant.hpp */; };
+		04F4627B26C4030D007CEEAB /* command_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A026C4030D007CEEAB /* command_path.hpp */; };
+		04F4627C26C4030D007CEEAB /* component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A126C4030D007CEEAB /* component.hpp */; };
+		04F4627D26C4030D007CEEAB /* node.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A226C4030D007CEEAB /* node.hpp */; };
+		04F4627E26C4030D007CEEAB /* layout.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A326C4030D007CEEAB /* layout.hpp */; };
+		04F4627F26C4030D007CEEAB /* drawable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A426C4030D007CEEAB /* drawable.hpp */; };
+		04F4628026C4030D007CEEAB /* artboard.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A526C4030D007CEEAB /* artboard.hpp */; };
+		04F4628126C4030D007CEEAB /* dependency_sorter.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A626C4030D007CEEAB /* dependency_sorter.hpp */; };
+		04F4628226C4030D007CEEAB /* core_context.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A726C4030D007CEEAB /* core_context.hpp */; };
+		04F4628326C4030D007CEEAB /* tendon.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461A926C4030D007CEEAB /* tendon.hpp */; };
+		04F4628426C4030D007CEEAB /* skeletal_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461AA26C4030D007CEEAB /* skeletal_component.hpp */; };
+		04F4628526C4030D007CEEAB /* weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461AB26C4030D007CEEAB /* weight.hpp */; };
+		04F4628626C4030D007CEEAB /* skin.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461AC26C4030D007CEEAB /* skin.hpp */; };
+		04F4628726C4030D007CEEAB /* root_bone.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461AD26C4030D007CEEAB /* root_bone.hpp */; };
+		04F4628826C4030D007CEEAB /* bone.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461AE26C4030D007CEEAB /* bone.hpp */; };
+		04F4628926C4030D007CEEAB /* skinnable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461AF26C4030D007CEEAB /* skinnable.hpp */; };
+		04F4628A26C4030D007CEEAB /* cubic_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461B026C4030D007CEEAB /* cubic_weight.hpp */; };
+		04F4628B26C4030D007CEEAB /* draw_rules.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461B126C4030D007CEEAB /* draw_rules.hpp */; };
+		04F4628C26C4030D007CEEAB /* core.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461B226C4030D007CEEAB /* core.hpp */; };
+		04F4628D26C4030D007CEEAB /* transform_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 04F461B326C4030D007CEEAB /* transform_component.hpp */; };
 		C9002A20263C76080011556B /* RiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9002A1F263C76080011556B /* RiveView.swift */; };
 		C9161A81263CBCBC007749A1 /* RiveRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9C73ED124FC478800EF9516 /* RiveRuntime.framework */; };
 		C9601F2B250C25930032AA07 /* RiveRenderer.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9601F2A250C25930032AA07 /* RiveRenderer.mm */; };
-		C9601F69251004780032AA07 /* vec2d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F2D251004770032AA07 /* vec2d.hpp */; };
-		C9601F6C251004780032AA07 /* color.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F30251004770032AA07 /* color.hpp */; };
-		C9601F6D251004780032AA07 /* transform_components.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F31251004770032AA07 /* transform_components.hpp */; };
-		C9601F70251004780032AA07 /* trim_path_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F34251004770032AA07 /* trim_path_base.hpp */; };
-		C9601F71251004780032AA07 /* command_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F35251004780032AA07 /* command_path.hpp */; };
-		C9601F73251004780032AA07 /* stroke_cap.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F38251004780032AA07 /* stroke_cap.hpp */; };
-		C9601F75251004780032AA07 /* stroke.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F3A251004780032AA07 /* stroke.hpp */; };
-		C9601F79251004780032AA07 /* stroke_join.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F3E251004780032AA07 /* stroke_join.hpp */; };
-		C9601F7A251004780032AA07 /* fill.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F3F251004780032AA07 /* fill.hpp */; };
-		C9601F7C251004780032AA07 /* trim_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F41251004780032AA07 /* trim_path.hpp */; };
-		C9601F7F251004780032AA07 /* linear_gradient.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F44251004780032AA07 /* linear_gradient.hpp */; };
-		C9601F80251004780032AA07 /* stroke_effect.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F45251004780032AA07 /* stroke_effect.hpp */; };
-		C9601F82251004780032AA07 /* straight_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F48251004780032AA07 /* straight_vertex.hpp */; };
-		C9601F84251004780032AA07 /* gradient_stop.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F4B251004780032AA07 /* gradient_stop.hpp */; };
-		C9601F86251004780032AA07 /* shape_paint_mutator.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F4D251004780032AA07 /* shape_paint_mutator.hpp */; };
-		C9601F87251004780032AA07 /* blend_mode.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F4E251004780032AA07 /* blend_mode.hpp */; };
-		C9601F88251004780032AA07 /* shape_paint.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F4F251004780032AA07 /* shape_paint.hpp */; };
-		C9601F8B251004780032AA07 /* radial_gradient.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F52251004780032AA07 /* radial_gradient.hpp */; };
-		C9601F8D251004780032AA07 /* color.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F54251004780032AA07 /* color.hpp */; };
-		C9601F8E251004780032AA07 /* solid_color.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F55251004780032AA07 /* solid_color.hpp */; };
-		C9601F91251004780032AA07 /* path_composer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F58251004780032AA07 /* path_composer.hpp */; };
-		C9601F92251004780032AA07 /* shape_paint_container.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F59251004780032AA07 /* shape_paint_container.hpp */; };
-		C9601F93251004780032AA07 /* cubic_mirrored_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F5A251004780032AA07 /* cubic_mirrored_vertex.hpp */; };
-		C9601F94251004780032AA07 /* path_space.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F5B251004780032AA07 /* path_space.hpp */; };
-		C9601F95251004780032AA07 /* ellipse.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F5C251004780032AA07 /* ellipse.hpp */; };
-		C9601F96251004780032AA07 /* clipping_shape.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F5D251004780032AA07 /* clipping_shape.hpp */; };
-		C9601F97251004780032AA07 /* metrics_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F5E251004780032AA07 /* metrics_path.hpp */; };
-		C9601F98251004780032AA07 /* cubic_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F5F251004780032AA07 /* cubic_vertex.hpp */; };
-		C9601F9A251004780032AA07 /* triangle.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F61251004780032AA07 /* triangle.hpp */; };
-		C9601F9B251004780032AA07 /* path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F62251004780032AA07 /* path.hpp */; };
-		C9601F9D251004780032AA07 /* parametric_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F64251004780032AA07 /* parametric_path.hpp */; };
-		C9601FA0251004780032AA07 /* cubic_asymmetric_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9601F67251004780032AA07 /* cubic_asymmetric_vertex.hpp */; };
 		C9601FAF251004950032AA07 /* trim_path.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9601FA2251004950032AA07 /* trim_path.cpp */; };
 		C9601FB0251004950032AA07 /* metrics_path.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9601FA3251004950032AA07 /* metrics_path.cpp */; };
 		C9601FB3251004950032AA07 /* shape_paint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9601FA7251004950032AA07 /* shape_paint.cpp */; };
 		C9601FB6251004950032AA07 /* color.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9601FAA251004950032AA07 /* color.cpp */; };
 		C9601FB9251004950032AA07 /* gradient_stop.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9601FAD251004950032AA07 /* gradient_stop.cpp */; };
 		C9601FBA251004950032AA07 /* stroke.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9601FAE251004950032AA07 /* stroke.cpp */; };
-		C98F296F2513FA8B0076E802 /* keyframe_id.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C98F296E2513FA8B0076E802 /* keyframe_id.hpp */; };
-		C98F29782513FAAE0076E802 /* draw_rules.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C98F29722513FAAE0076E802 /* draw_rules.hpp */; };
-		C98F29792513FAAE0076E802 /* draw_target_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C98F29732513FAAE0076E802 /* draw_target_base.hpp */; };
-		C98F297A2513FAAE0076E802 /* draw_rules_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C98F29742513FAAE0076E802 /* draw_rules_base.hpp */; };
-		C98F297B2513FAAE0076E802 /* draw_target_placement.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C98F29752513FAAE0076E802 /* draw_target_placement.hpp */; };
-		C98F297C2513FAAE0076E802 /* draw_target.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C98F29762513FAAE0076E802 /* draw_target.hpp */; };
-		C98F297D2513FAAE0076E802 /* keyframe_id_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C98F29772513FAAE0076E802 /* keyframe_id_base.hpp */; };
 		C98F29832513FAC30076E802 /* draw_target.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C98F29802513FAC30076E802 /* draw_target.cpp */; };
 		C98F29842513FAC30076E802 /* keyframe_id.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C98F29812513FAC30076E802 /* keyframe_id.cpp */; };
 		C98F29852513FAC30076E802 /* draw_rules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C98F29822513FAC30076E802 /* draw_rules.cpp */; };
-		C9A9D9F2265C50930005DB1F /* blend_state_direct_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9D9E5265C50930005DB1F /* blend_state_direct_instance.hpp */; };
-		C9A9D9F3265C50930005DB1F /* blend_state_direct.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9D9E6265C50930005DB1F /* blend_state_direct.hpp */; };
-		C9A9D9F4265C50930005DB1F /* blend_animation_direct.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9D9E7265C50930005DB1F /* blend_animation_direct.hpp */; };
-		C9A9D9F5265C50930005DB1F /* blend_animation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9D9E8265C50930005DB1F /* blend_animation.hpp */; };
-		C9A9D9F6265C50930005DB1F /* blend_state_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9D9E9265C50930005DB1F /* blend_state_instance.hpp */; };
-		C9A9D9F7265C50930005DB1F /* blend_state_1d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9D9EA265C50930005DB1F /* blend_state_1d.hpp */; };
-		C9A9D9F8265C50930005DB1F /* blend_animation_1d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9D9EB265C50930005DB1F /* blend_animation_1d.hpp */; };
-		C9A9D9F9265C50930005DB1F /* system_state_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9D9EC265C50930005DB1F /* system_state_instance.hpp */; };
-		C9A9D9FA265C50930005DB1F /* blend_state_transition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9D9ED265C50930005DB1F /* blend_state_transition.hpp */; };
-		C9A9D9FB265C50930005DB1F /* animation_state_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9D9EE265C50930005DB1F /* animation_state_instance.hpp */; };
-		C9A9D9FC265C50930005DB1F /* state_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9D9EF265C50930005DB1F /* state_instance.hpp */; };
-		C9A9D9FD265C50930005DB1F /* blend_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9D9F0265C50930005DB1F /* blend_state.hpp */; };
-		C9A9D9FE265C50930005DB1F /* blend_state_1d_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9D9F1265C50930005DB1F /* blend_state_1d_instance.hpp */; };
-		C9A9DA06265C50CA0005DB1F /* blend_animation_direct_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9D9FF265C50C90005DB1F /* blend_animation_direct_base.hpp */; };
-		C9A9DA07265C50CA0005DB1F /* blend_state_direct_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9DA00265C50C90005DB1F /* blend_state_direct_base.hpp */; };
-		C9A9DA08265C50CA0005DB1F /* blend_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9DA01265C50C90005DB1F /* blend_state_base.hpp */; };
-		C9A9DA09265C50CA0005DB1F /* blend_animation_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9DA02265C50C90005DB1F /* blend_animation_base.hpp */; };
-		C9A9DA0A265C50CA0005DB1F /* blend_state_1d_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9DA03265C50C90005DB1F /* blend_state_1d_base.hpp */; };
-		C9A9DA0B265C50CA0005DB1F /* blend_animation_1d_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9DA04265C50C90005DB1F /* blend_animation_1d_base.hpp */; };
-		C9A9DA0C265C50CA0005DB1F /* blend_state_transition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9A9DA05265C50CA0005DB1F /* blend_state_transition_base.hpp */; };
 		C9A9DA19265C51100005DB1F /* blend_animation_direct.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A9DA0D265C510F0005DB1F /* blend_animation_direct.cpp */; };
 		C9A9DA1A265C51100005DB1F /* blend_state.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A9DA0E265C510F0005DB1F /* blend_state.cpp */; };
 		C9A9DA1B265C51100005DB1F /* animation_state_instance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A9DA0F265C510F0005DB1F /* animation_state_instance.cpp */; };
@@ -207,63 +354,8 @@
 		C9A9DA8D265C51A40005DB1F /* root_bone_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A9DA5A265C51A40005DB1F /* root_bone_base.cpp */; };
 		C9A9DA8E265C51A40005DB1F /* cubic_weight_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A9DA5B265C51A40005DB1F /* cubic_weight_base.cpp */; };
 		C9A9DA8F265C51A40005DB1F /* node_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A9DA5C265C51A40005DB1F /* node_base.cpp */; };
-		C9AEB7E825C8903C00AE9C43 /* star_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9AEB7E625C8903C00AE9C43 /* star_base.hpp */; };
-		C9AEB7E925C8903C00AE9C43 /* polygon_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9AEB7E725C8903C00AE9C43 /* polygon_base.hpp */; };
 		C9AEB7EE25C8904E00AE9C43 /* star.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9AEB7EC25C8904E00AE9C43 /* star.cpp */; };
 		C9AEB7EF25C8904E00AE9C43 /* polygon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9AEB7ED25C8904E00AE9C43 /* polygon.cpp */; };
-		C9BD3893263B5D8300696C37 /* state_machine_number_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD388F263B5D8200696C37 /* state_machine_number_base.hpp */; };
-		C9BD3894263B5D8300696C37 /* state_transition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD3890263B5D8200696C37 /* state_transition_base.hpp */; };
-		C9BD3895263B5D8300696C37 /* transition_number_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD3891263B5D8200696C37 /* transition_number_condition_base.hpp */; };
-		C9BD3896263B5D8300696C37 /* state_machine_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD3892263B5D8200696C37 /* state_machine_component_base.hpp */; };
-		C9BD38A5263B5D9000696C37 /* transition_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD3897263B5D8F00696C37 /* transition_condition_base.hpp */; };
-		C9BD38A6263B5D9000696C37 /* transition_bool_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD3898263B5D8F00696C37 /* transition_bool_condition_base.hpp */; };
-		C9BD38A7263B5D9000696C37 /* transition_trigger_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD3899263B5D8F00696C37 /* transition_trigger_condition_base.hpp */; };
-		C9BD38A8263B5D9000696C37 /* state_machine_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD389A263B5D8F00696C37 /* state_machine_base.hpp */; };
-		C9BD38A9263B5D9000696C37 /* layer_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD389B263B5D8F00696C37 /* layer_state_base.hpp */; };
-		C9BD38AA263B5D9000696C37 /* state_machine_layer_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD389C263B5D9000696C37 /* state_machine_layer_base.hpp */; };
-		C9BD38AB263B5D9000696C37 /* state_machine_input_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD389D263B5D9000696C37 /* state_machine_input_base.hpp */; };
-		C9BD38AC263B5D9000696C37 /* transition_value_condition_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD389E263B5D9000696C37 /* transition_value_condition_base.hpp */; };
-		C9BD38AD263B5D9000696C37 /* state_machine_trigger_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD389F263B5D9000696C37 /* state_machine_trigger_base.hpp */; };
-		C9BD38AE263B5D9000696C37 /* state_machine_bool_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38A0263B5D9000696C37 /* state_machine_bool_base.hpp */; };
-		C9BD38AF263B5D9000696C37 /* entry_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38A1263B5D9000696C37 /* entry_state_base.hpp */; };
-		C9BD38B0263B5D9000696C37 /* any_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38A2263B5D9000696C37 /* any_state_base.hpp */; };
-		C9BD38B1263B5D9000696C37 /* exit_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38A3263B5D9000696C37 /* exit_state_base.hpp */; };
-		C9BD38B2263B5D9000696C37 /* state_machine_layer_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38A4263B5D9000696C37 /* state_machine_layer_component_base.hpp */; };
-		C9BD38B4263B5DAE00696C37 /* animation_state_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38B3263B5DAE00696C37 /* animation_state_base.hpp */; };
-		C9BD38B7263B5DD400696C37 /* polygon.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38B5263B5DD400696C37 /* polygon.hpp */; };
-		C9BD38B8263B5DD400696C37 /* star.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38B6263B5DD400696C37 /* star.hpp */; };
-		C9BD38C3263B5E0D00696C37 /* state_transition_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38BA263B5E0D00696C37 /* state_transition_importer.hpp */; };
-		C9BD38C4263B5E0D00696C37 /* state_machine_layer_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38BB263B5E0D00696C37 /* state_machine_layer_importer.hpp */; };
-		C9BD38C5263B5E0D00696C37 /* keyed_property_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38BC263B5E0D00696C37 /* keyed_property_importer.hpp */; };
-		C9BD38C6263B5E0D00696C37 /* keyed_object_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38BD263B5E0D00696C37 /* keyed_object_importer.hpp */; };
-		C9BD38C7263B5E0D00696C37 /* linear_animation_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38BE263B5E0D00696C37 /* linear_animation_importer.hpp */; };
-		C9BD38C8263B5E0D00696C37 /* import_stack.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38BF263B5E0D00696C37 /* import_stack.hpp */; };
-		C9BD38C9263B5E0D00696C37 /* layer_state_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38C0263B5E0D00696C37 /* layer_state_importer.hpp */; };
-		C9BD38CA263B5E0D00696C37 /* artboard_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38C1263B5E0D00696C37 /* artboard_importer.hpp */; };
-		C9BD38CB263B5E0D00696C37 /* state_machine_importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38C2263B5E0D00696C37 /* state_machine_importer.hpp */; };
-		C9BD38E3263B5E4000696C37 /* transition_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38CC263B5E4000696C37 /* transition_condition.hpp */; };
-		C9BD38E4263B5E4000696C37 /* state_transition_flags.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38CD263B5E4000696C37 /* state_transition_flags.hpp */; };
-		C9BD38E5263B5E4000696C37 /* entry_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38CE263B5E4000696C37 /* entry_state.hpp */; };
-		C9BD38E6263B5E4000696C37 /* state_machine_layer_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38CF263B5E4000696C37 /* state_machine_layer_component.hpp */; };
-		C9BD38E7263B5E4000696C37 /* transition_value_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38D0263B5E4000696C37 /* transition_value_condition.hpp */; };
-		C9BD38E8263B5E4000696C37 /* transition_bool_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38D1263B5E4000696C37 /* transition_bool_condition.hpp */; };
-		C9BD38E9263B5E4000696C37 /* state_machine_bool.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38D2263B5E4000696C37 /* state_machine_bool.hpp */; };
-		C9BD38EA263B5E4000696C37 /* animation_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38D3263B5E4000696C37 /* animation_state.hpp */; };
-		C9BD38EB263B5E4000696C37 /* state_machine_trigger.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38D4263B5E4000696C37 /* state_machine_trigger.hpp */; };
-		C9BD38EC263B5E4000696C37 /* state_machine_number.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38D5263B5E4000696C37 /* state_machine_number.hpp */; };
-		C9BD38ED263B5E4000696C37 /* state_machine.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38D6263B5E4000696C37 /* state_machine.hpp */; };
-		C9BD38EE263B5E4000696C37 /* state_transition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38D7263B5E4000696C37 /* state_transition.hpp */; };
-		C9BD38EF263B5E4000696C37 /* any_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38D8263B5E4000696C37 /* any_state.hpp */; };
-		C9BD38F0263B5E4000696C37 /* state_machine_input.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38D9263B5E4000696C37 /* state_machine_input.hpp */; };
-		C9BD38F1263B5E4000696C37 /* state_machine_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38DA263B5E4000696C37 /* state_machine_component.hpp */; };
-		C9BD38F2263B5E4000696C37 /* transition_condition_op.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38DB263B5E4000696C37 /* transition_condition_op.hpp */; };
-		C9BD38F3263B5E4000696C37 /* transition_trigger_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38DC263B5E4000696C37 /* transition_trigger_condition.hpp */; };
-		C9BD38F4263B5E4000696C37 /* state_machine_input_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38DD263B5E4000696C37 /* state_machine_input_instance.hpp */; };
-		C9BD38F5263B5E4000696C37 /* transition_number_condition.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38DE263B5E4000696C37 /* transition_number_condition.hpp */; };
-		C9BD38F6263B5E4000696C37 /* exit_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38DF263B5E4000696C37 /* exit_state.hpp */; };
-		C9BD38F7263B5E4000696C37 /* layer_state.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38E0263B5E4000696C37 /* layer_state.hpp */; };
-		C9BD38F8263B5E4000696C37 /* state_machine_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38E1263B5E4000696C37 /* state_machine_instance.hpp */; };
-		C9BD38F9263B5E4000696C37 /* state_machine_layer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9BD38E2263B5E4000696C37 /* state_machine_layer.hpp */; };
 		C9BD3903263B5E7600696C37 /* artboard_importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9BD38FB263B5E7600696C37 /* artboard_importer.cpp */; };
 		C9BD3904263B5E7600696C37 /* state_machine_importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9BD38FC263B5E7600696C37 /* state_machine_importer.cpp */; };
 		C9BD3905263B5E7600696C37 /* linear_animation_importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9BD38FD263B5E7600696C37 /* linear_animation_importer.cpp */; };
@@ -338,99 +430,6 @@
 		C9C7416C24FC4F0500EF9516 /* weight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9C740AA24FC4F0400EF9516 /* weight.cpp */; };
 		C9C7416D24FC4F0500EF9516 /* skin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9C740AB24FC4F0400EF9516 /* skin.cpp */; };
 		C9C7416E24FC4F0500EF9516 /* tendon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9C740AC24FC4F0400EF9516 /* tendon.cpp */; };
-		C9C7416F24FC4F0500EF9516 /* core_registry.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740AF24FC4F0400EF9516 /* core_registry.hpp */; };
-		C9C7417024FC4F0500EF9516 /* node_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740B024FC4F0400EF9516 /* node_base.hpp */; };
-		C9C7417124FC4F0500EF9516 /* transform_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740B124FC4F0400EF9516 /* transform_component_base.hpp */; };
-		C9C7417224FC4F0500EF9516 /* artboard_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740B224FC4F0400EF9516 /* artboard_base.hpp */; };
-		C9C7417324FC4F0500EF9516 /* keyframe_color_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740B424FC4F0400EF9516 /* keyframe_color_base.hpp */; };
-		C9C7417424FC4F0500EF9516 /* keyed_property_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740B524FC4F0400EF9516 /* keyed_property_base.hpp */; };
-		C9C7417524FC4F0500EF9516 /* keyframe_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740B624FC4F0400EF9516 /* keyframe_base.hpp */; };
-		C9C7417624FC4F0500EF9516 /* animation_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740B724FC4F0400EF9516 /* animation_base.hpp */; };
-		C9C7417724FC4F0500EF9516 /* cubic_interpolator_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740B824FC4F0400EF9516 /* cubic_interpolator_base.hpp */; };
-		C9C7417A24FC4F0500EF9516 /* linear_animation_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740BB24FC4F0400EF9516 /* linear_animation_base.hpp */; };
-		C9C7417B24FC4F0500EF9516 /* keyed_object_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740BC24FC4F0400EF9516 /* keyed_object_base.hpp */; };
-		C9C7417C24FC4F0500EF9516 /* keyframe_double_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740BD24FC4F0400EF9516 /* keyframe_double_base.hpp */; };
-		C9C7417D24FC4F0500EF9516 /* linear_gradient_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740C024FC4F0400EF9516 /* linear_gradient_base.hpp */; };
-		C9C7417E24FC4F0500EF9516 /* stroke_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740C124FC4F0400EF9516 /* stroke_base.hpp */; };
-		C9C7417F24FC4F0500EF9516 /* fill_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740C224FC4F0400EF9516 /* fill_base.hpp */; };
-		C9C7418024FC4F0500EF9516 /* shape_paint_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740C324FC4F0400EF9516 /* shape_paint_base.hpp */; };
-		C9C7418124FC4F0500EF9516 /* solid_color_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740C424FC4F0400EF9516 /* solid_color_base.hpp */; };
-		C9C7418224FC4F0500EF9516 /* radial_gradient_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740C524FC4F0400EF9516 /* radial_gradient_base.hpp */; };
-		C9C7418324FC4F0500EF9516 /* gradient_stop_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740C624FC4F0400EF9516 /* gradient_stop_base.hpp */; };
-		C9C7418424FC4F0500EF9516 /* parametric_path_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740C724FC4F0400EF9516 /* parametric_path_base.hpp */; };
-		C9C7418524FC4F0500EF9516 /* cubic_asymmetric_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740C824FC4F0400EF9516 /* cubic_asymmetric_vertex_base.hpp */; };
-		C9C7418624FC4F0500EF9516 /* cubic_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740C924FC4F0400EF9516 /* cubic_vertex_base.hpp */; };
-		C9C7418724FC4F0500EF9516 /* ellipse_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740CA24FC4F0400EF9516 /* ellipse_base.hpp */; };
-		C9C7418824FC4F0500EF9516 /* path_composer_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740CB24FC4F0400EF9516 /* path_composer_base.hpp */; };
-		C9C7418924FC4F0500EF9516 /* points_path_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740CC24FC4F0400EF9516 /* points_path_base.hpp */; };
-		C9C7418A24FC4F0500EF9516 /* triangle_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740CD24FC4F0400EF9516 /* triangle_base.hpp */; };
-		C9C7418B24FC4F0500EF9516 /* shape_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740CE24FC4F0400EF9516 /* shape_base.hpp */; };
-		C9C7418C24FC4F0500EF9516 /* rectangle_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740CF24FC4F0400EF9516 /* rectangle_base.hpp */; };
-		C9C7418D24FC4F0500EF9516 /* cubic_mirrored_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740D024FC4F0400EF9516 /* cubic_mirrored_vertex_base.hpp */; };
-		C9C7418E24FC4F0500EF9516 /* straight_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740D124FC4F0400EF9516 /* straight_vertex_base.hpp */; };
-		C9C7418F24FC4F0500EF9516 /* path_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740D224FC4F0400EF9516 /* path_base.hpp */; };
-		C9C7419024FC4F0500EF9516 /* cubic_detached_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740D324FC4F0400EF9516 /* cubic_detached_vertex_base.hpp */; };
-		C9C7419124FC4F0500EF9516 /* clipping_shape_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740D424FC4F0400EF9516 /* clipping_shape_base.hpp */; };
-		C9C7419224FC4F0500EF9516 /* path_vertex_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740D524FC4F0400EF9516 /* path_vertex_base.hpp */; };
-		C9C7419324FC4F0500EF9516 /* container_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740D624FC4F0400EF9516 /* container_component_base.hpp */; };
-		C9C7419424FC4F0500EF9516 /* component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740D724FC4F0400EF9516 /* component_base.hpp */; };
-		C9C7419524FC4F0500EF9516 /* weight_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740D924FC4F0400EF9516 /* weight_base.hpp */; };
-		C9C7419624FC4F0500EF9516 /* root_bone_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740DA24FC4F0400EF9516 /* root_bone_base.hpp */; };
-		C9C7419724FC4F0500EF9516 /* cubic_weight_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740DB24FC4F0400EF9516 /* cubic_weight_base.hpp */; };
-		C9C7419824FC4F0500EF9516 /* bone_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740DC24FC4F0400EF9516 /* bone_base.hpp */; };
-		C9C7419924FC4F0500EF9516 /* skin_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740DD24FC4F0400EF9516 /* skin_base.hpp */; };
-		C9C7419A24FC4F0500EF9516 /* tendon_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740DE24FC4F0400EF9516 /* tendon_base.hpp */; };
-		C9C7419B24FC4F0500EF9516 /* skeletal_component_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740DF24FC4F0400EF9516 /* skeletal_component_base.hpp */; };
-		C9C7419C24FC4F0500EF9516 /* backboard_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740E024FC4F0400EF9516 /* backboard_base.hpp */; };
-		C9C7419D24FC4F0500EF9516 /* drawable_base.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740E124FC4F0400EF9516 /* drawable_base.hpp */; };
-		C9C7419E24FC4F0500EF9516 /* backboard.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740E224FC4F0400EF9516 /* backboard.hpp */; };
-		C9C7419F24FC4F0500EF9516 /* reader.h in Headers */ = {isa = PBXBuildFile; fileRef = C9C740E424FC4F0400EF9516 /* reader.h */; };
-		C9C741A024FC4F0500EF9516 /* core_color_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740E624FC4F0400EF9516 /* core_color_type.hpp */; };
-		C9C741A124FC4F0500EF9516 /* core_uint_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740E724FC4F0400EF9516 /* core_uint_type.hpp */; };
-		C9C741A224FC4F0500EF9516 /* core_double_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740E824FC4F0400EF9516 /* core_double_type.hpp */; };
-		C9C741A324FC4F0500EF9516 /* core_string_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740E924FC4F0400EF9516 /* core_string_type.hpp */; };
-		C9C741A424FC4F0500EF9516 /* core_bool_type.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740EA24FC4F0400EF9516 /* core_bool_type.hpp */; };
-		C9C741A524FC4F0500EF9516 /* binary_reader.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740EB24FC4F0400EF9516 /* binary_reader.hpp */; };
-		C9C741A624FC4F0500EF9516 /* status_code.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740EC24FC4F0400EF9516 /* status_code.hpp */; };
-		C9C741A724FC4F0500EF9516 /* component_dirt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740ED24FC4F0400EF9516 /* component_dirt.hpp */; };
-		C9C741A824FC4F0500EF9516 /* renderer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740EE24FC4F0400EF9516 /* renderer.hpp */; };
-		C9C741AA24FC4F0500EF9516 /* file.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740F024FC4F0400EF9516 /* file.hpp */; };
-		C9C741AB24FC4F0500EF9516 /* container_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740F124FC4F0400EF9516 /* container_component.hpp */; };
-		C9C741AC24FC4F0500EF9516 /* cubic_interpolator.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740F324FC4F0500EF9516 /* cubic_interpolator.hpp */; };
-		C9C741AD24FC4F0500EF9516 /* keyed_property.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740F424FC4F0500EF9516 /* keyed_property.hpp */; };
-		C9C741B024FC4F0500EF9516 /* animation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740F724FC4F0500EF9516 /* animation.hpp */; };
-		C9C741B124FC4F0500EF9516 /* keyframe.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740F824FC4F0500EF9516 /* keyframe.hpp */; };
-		C9C741B224FC4F0500EF9516 /* keyed_object.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740F924FC4F0500EF9516 /* keyed_object.hpp */; };
-		C9C741B324FC4F0500EF9516 /* linear_animation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740FA24FC4F0500EF9516 /* linear_animation.hpp */; };
-		C9C741B424FC4F0500EF9516 /* linear_animation_instance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740FB24FC4F0500EF9516 /* linear_animation_instance.hpp */; };
-		C9C741B524FC4F0500EF9516 /* keyframe_double.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740FC24FC4F0500EF9516 /* keyframe_double.hpp */; };
-		C9C741B624FC4F0500EF9516 /* loop.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740FD24FC4F0500EF9516 /* loop.hpp */; };
-		C9C741B724FC4F0500EF9516 /* keyframe_color.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C740FE24FC4F0500EF9516 /* keyframe_color.hpp */; };
-		C9C741CC24FC4F0500EF9516 /* shape.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7411524FC4F0500EF9516 /* shape.hpp */; };
-		C9C741CF24FC4F0500EF9516 /* path_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7411824FC4F0500EF9516 /* path_vertex.hpp */; };
-		C9C741D124FC4F0500EF9516 /* rectangle.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7411A24FC4F0500EF9516 /* rectangle.hpp */; };
-		C9C741D224FC4F0500EF9516 /* points_path.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7411B24FC4F0500EF9516 /* points_path.hpp */; };
-		C9C741D424FC4F0500EF9516 /* cubic_detached_vertex.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7411D24FC4F0500EF9516 /* cubic_detached_vertex.hpp */; };
-		C9C741D624FC4F0500EF9516 /* mat2d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7412024FC4F0500EF9516 /* mat2d.hpp */; };
-		C9C741D724FC4F0500EF9516 /* aabb.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7412124FC4F0500EF9516 /* aabb.hpp */; };
-		C9C741DA24FC4F0500EF9516 /* circle_constant.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7412424FC4F0500EF9516 /* circle_constant.hpp */; };
-		C9C741DB24FC4F0500EF9516 /* component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7412524FC4F0500EF9516 /* component.hpp */; };
-		C9C741DC24FC4F0500EF9516 /* node.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7412624FC4F0500EF9516 /* node.hpp */; };
-		C9C741DD24FC4F0500EF9516 /* layout.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7412724FC4F0500EF9516 /* layout.hpp */; };
-		C9C741DE24FC4F0500EF9516 /* drawable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7412824FC4F0500EF9516 /* drawable.hpp */; };
-		C9C741DF24FC4F0500EF9516 /* artboard.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7412924FC4F0500EF9516 /* artboard.hpp */; };
-		C9C741E024FC4F0500EF9516 /* dependency_sorter.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7412A24FC4F0500EF9516 /* dependency_sorter.hpp */; };
-		C9C741E124FC4F0500EF9516 /* core_context.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7412B24FC4F0500EF9516 /* core_context.hpp */; };
-		C9C741E224FC4F0500EF9516 /* tendon.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7412D24FC4F0500EF9516 /* tendon.hpp */; };
-		C9C741E324FC4F0500EF9516 /* skeletal_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7412E24FC4F0500EF9516 /* skeletal_component.hpp */; };
-		C9C741E424FC4F0500EF9516 /* weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7412F24FC4F0500EF9516 /* weight.hpp */; };
-		C9C741E524FC4F0500EF9516 /* skin.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7413024FC4F0500EF9516 /* skin.hpp */; };
-		C9C741E624FC4F0500EF9516 /* root_bone.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7413124FC4F0500EF9516 /* root_bone.hpp */; };
-		C9C741E724FC4F0500EF9516 /* bone.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7413224FC4F0500EF9516 /* bone.hpp */; };
-		C9C741E824FC4F0500EF9516 /* skinnable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7413324FC4F0500EF9516 /* skinnable.hpp */; };
-		C9C741E924FC4F0500EF9516 /* cubic_weight.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7413424FC4F0500EF9516 /* cubic_weight.hpp */; };
-		C9C741EA24FC4F0500EF9516 /* core.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7413524FC4F0500EF9516 /* core.hpp */; };
-		C9C741EB24FC4F0500EF9516 /* transform_component.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9C7413624FC4F0500EF9516 /* transform_component.hpp */; };
 		C9C741F424FC510200EF9516 /* Rive.h in Headers */ = {isa = PBXBuildFile; fileRef = C9C741F224FC510200EF9516 /* Rive.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C9C741F524FC510200EF9516 /* Rive.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9C741F324FC510200EF9516 /* Rive.mm */; };
 		C9CE8253263B716F00F98DDB /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9CE8252263B716F00F98DDB /* UIKit.framework */; };
@@ -450,11 +449,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0450446226B3F74A007B25CA /* transform_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_constraint.hpp; sourceTree = "<group>"; };
-		0450446326B3F74A007B25CA /* distance_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = distance_constraint.hpp; sourceTree = "<group>"; };
-		0450446626B3F7A5007B25CA /* distance_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = distance_constraint_base.hpp; sourceTree = "<group>"; };
-		0450446726B3F7A5007B25CA /* transform_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_constraint_base.hpp; sourceTree = "<group>"; };
-		0450446A26B3F7C1007B25CA /* transform_space.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_space.hpp; sourceTree = "<group>"; };
 		0450446C26B3F82D007B25CA /* distance_constraint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = distance_constraint.cpp; sourceTree = "<group>"; };
 		0450446D26B3F82D007B25CA /* transform_constraint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transform_constraint.cpp; sourceTree = "<group>"; };
 		0450447026B3F83C007B25CA /* distance_constraint_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = distance_constraint_base.cpp; sourceTree = "<group>"; };
@@ -510,72 +504,227 @@
 		04F1C92C26A84B8700CEE6BE /* blend_state_transition_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = blend_state_transition_base.cpp; sourceTree = "<group>"; };
 		04F1C92D26A84B8700CEE6BE /* blend_state_1d_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = blend_state_1d_base.cpp; sourceTree = "<group>"; };
 		04F1C92E26A84B8700CEE6BE /* blend_state_direct_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = blend_state_direct_base.cpp; sourceTree = "<group>"; };
-		04F1C93526A84BB400CEE6BE /* targeted_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = targeted_constraint.hpp; sourceTree = "<group>"; };
-		04F1C93626A84BB400CEE6BE /* constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = constraint.hpp; sourceTree = "<group>"; };
-		04F1C93726A84BB400CEE6BE /* ik_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ik_constraint.hpp; sourceTree = "<group>"; };
-		04F1C93C26A84BD900CEE6BE /* constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = constraint_base.hpp; sourceTree = "<group>"; };
-		04F1C93D26A84BD900CEE6BE /* targeted_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = targeted_constraint_base.hpp; sourceTree = "<group>"; };
-		04F1C93E26A84BD900CEE6BE /* ik_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ik_constraint_base.hpp; sourceTree = "<group>"; };
+		04F460CC26C4030C007CEEAB /* core_registry.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_registry.hpp; sourceTree = "<group>"; };
+		04F460CD26C4030C007CEEAB /* node_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = node_base.hpp; sourceTree = "<group>"; };
+		04F460CE26C4030C007CEEAB /* transform_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_component_base.hpp; sourceTree = "<group>"; };
+		04F460D026C4030C007CEEAB /* constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = constraint_base.hpp; sourceTree = "<group>"; };
+		04F460D126C4030C007CEEAB /* targeted_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = targeted_constraint_base.hpp; sourceTree = "<group>"; };
+		04F460D226C4030C007CEEAB /* ik_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ik_constraint_base.hpp; sourceTree = "<group>"; };
+		04F460D326C4030C007CEEAB /* transform_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_constraint_base.hpp; sourceTree = "<group>"; };
+		04F460D426C4030C007CEEAB /* distance_constraint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = distance_constraint_base.hpp; sourceTree = "<group>"; };
+		04F460D526C4030C007CEEAB /* artboard_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = artboard_base.hpp; sourceTree = "<group>"; };
+		04F460D626C4030C007CEEAB /* draw_rules_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_rules_base.hpp; sourceTree = "<group>"; };
+		04F460D826C4030C007CEEAB /* blend_animation_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_base.hpp; sourceTree = "<group>"; };
+		04F460D926C4030C007CEEAB /* keyframe_color_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_color_base.hpp; sourceTree = "<group>"; };
+		04F460DA26C4030C007CEEAB /* keyed_property_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_property_base.hpp; sourceTree = "<group>"; };
+		04F460DB26C4030C007CEEAB /* keyframe_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_base.hpp; sourceTree = "<group>"; };
+		04F460DC26C4030C007CEEAB /* animation_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_state_base.hpp; sourceTree = "<group>"; };
+		04F460DD26C4030C007CEEAB /* animation_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_base.hpp; sourceTree = "<group>"; };
+		04F460DE26C4030C007CEEAB /* blend_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_base.hpp; sourceTree = "<group>"; };
+		04F460DF26C4030C007CEEAB /* transition_number_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_number_condition_base.hpp; sourceTree = "<group>"; };
+		04F460E026C4030C007CEEAB /* cubic_interpolator_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_interpolator_base.hpp; sourceTree = "<group>"; };
+		04F460E126C4030C007CEEAB /* linear_animation_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_animation_base.hpp; sourceTree = "<group>"; };
+		04F460E226C4030C007CEEAB /* entry_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = entry_state_base.hpp; sourceTree = "<group>"; };
+		04F460E326C4030C007CEEAB /* layer_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = layer_state_base.hpp; sourceTree = "<group>"; };
+		04F460E426C4030C007CEEAB /* state_machine_layer_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer_component_base.hpp; sourceTree = "<group>"; };
+		04F460E526C4030C007CEEAB /* blend_state_direct_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_direct_base.hpp; sourceTree = "<group>"; };
+		04F460E626C4030C007CEEAB /* state_machine_layer_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer_base.hpp; sourceTree = "<group>"; };
+		04F460E726C4030C007CEEAB /* keyframe_id_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_id_base.hpp; sourceTree = "<group>"; };
+		04F460E826C4030C007CEEAB /* blend_animation_1d_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_1d_base.hpp; sourceTree = "<group>"; };
+		04F460E926C4030C007CEEAB /* keyed_object_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_object_base.hpp; sourceTree = "<group>"; };
+		04F460EA26C4030C007CEEAB /* transition_value_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_value_condition_base.hpp; sourceTree = "<group>"; };
+		04F460EB26C4030C007CEEAB /* state_machine_number_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_number_base.hpp; sourceTree = "<group>"; };
+		04F460EC26C4030C007CEEAB /* state_transition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_transition_base.hpp; sourceTree = "<group>"; };
+		04F460ED26C4030C007CEEAB /* keyframe_double_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_double_base.hpp; sourceTree = "<group>"; };
+		04F460EE26C4030C007CEEAB /* state_machine_bool_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_bool_base.hpp; sourceTree = "<group>"; };
+		04F460EF26C4030C007CEEAB /* blend_state_transition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_transition_base.hpp; sourceTree = "<group>"; };
+		04F460F026C4030C007CEEAB /* blend_animation_direct_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_direct_base.hpp; sourceTree = "<group>"; };
+		04F460F126C4030C007CEEAB /* transition_bool_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_bool_condition_base.hpp; sourceTree = "<group>"; };
+		04F460F226C4030C007CEEAB /* transition_trigger_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_trigger_condition_base.hpp; sourceTree = "<group>"; };
+		04F460F326C4030C007CEEAB /* state_machine_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_component_base.hpp; sourceTree = "<group>"; };
+		04F460F426C4030C007CEEAB /* any_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = any_state_base.hpp; sourceTree = "<group>"; };
+		04F460F526C4030C007CEEAB /* transition_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_condition_base.hpp; sourceTree = "<group>"; };
+		04F460F626C4030C007CEEAB /* state_machine_input_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_input_base.hpp; sourceTree = "<group>"; };
+		04F460F726C4030D007CEEAB /* blend_state_1d_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_1d_base.hpp; sourceTree = "<group>"; };
+		04F460F826C4030D007CEEAB /* state_machine_trigger_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_trigger_base.hpp; sourceTree = "<group>"; };
+		04F460F926C4030D007CEEAB /* state_machine_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_base.hpp; sourceTree = "<group>"; };
+		04F460FA26C4030D007CEEAB /* exit_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = exit_state_base.hpp; sourceTree = "<group>"; };
+		04F460FD26C4030D007CEEAB /* linear_gradient_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_gradient_base.hpp; sourceTree = "<group>"; };
+		04F460FE26C4030D007CEEAB /* stroke_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_base.hpp; sourceTree = "<group>"; };
+		04F460FF26C4030D007CEEAB /* fill_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fill_base.hpp; sourceTree = "<group>"; };
+		04F4610026C4030D007CEEAB /* shape_paint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint_base.hpp; sourceTree = "<group>"; };
+		04F4610126C4030D007CEEAB /* solid_color_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = solid_color_base.hpp; sourceTree = "<group>"; };
+		04F4610226C4030D007CEEAB /* trim_path_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = trim_path_base.hpp; sourceTree = "<group>"; };
+		04F4610326C4030D007CEEAB /* radial_gradient_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = radial_gradient_base.hpp; sourceTree = "<group>"; };
+		04F4610426C4030D007CEEAB /* gradient_stop_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = gradient_stop_base.hpp; sourceTree = "<group>"; };
+		04F4610526C4030D007CEEAB /* parametric_path_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = parametric_path_base.hpp; sourceTree = "<group>"; };
+		04F4610626C4030D007CEEAB /* cubic_asymmetric_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_asymmetric_vertex_base.hpp; sourceTree = "<group>"; };
+		04F4610726C4030D007CEEAB /* cubic_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_vertex_base.hpp; sourceTree = "<group>"; };
+		04F4610826C4030D007CEEAB /* ellipse_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ellipse_base.hpp; sourceTree = "<group>"; };
+		04F4610926C4030D007CEEAB /* points_path_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = points_path_base.hpp; sourceTree = "<group>"; };
+		04F4610A26C4030D007CEEAB /* triangle_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = triangle_base.hpp; sourceTree = "<group>"; };
+		04F4610B26C4030D007CEEAB /* shape_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_base.hpp; sourceTree = "<group>"; };
+		04F4610C26C4030D007CEEAB /* rectangle_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = rectangle_base.hpp; sourceTree = "<group>"; };
+		04F4610D26C4030D007CEEAB /* cubic_mirrored_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_mirrored_vertex_base.hpp; sourceTree = "<group>"; };
+		04F4610E26C4030D007CEEAB /* star_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = star_base.hpp; sourceTree = "<group>"; };
+		04F4610F26C4030D007CEEAB /* straight_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = straight_vertex_base.hpp; sourceTree = "<group>"; };
+		04F4611026C4030D007CEEAB /* path_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_base.hpp; sourceTree = "<group>"; };
+		04F4611126C4030D007CEEAB /* polygon_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = polygon_base.hpp; sourceTree = "<group>"; };
+		04F4611226C4030D007CEEAB /* cubic_detached_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_detached_vertex_base.hpp; sourceTree = "<group>"; };
+		04F4611326C4030D007CEEAB /* clipping_shape_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = clipping_shape_base.hpp; sourceTree = "<group>"; };
+		04F4611426C4030D007CEEAB /* path_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_vertex_base.hpp; sourceTree = "<group>"; };
+		04F4611526C4030D007CEEAB /* container_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = container_component_base.hpp; sourceTree = "<group>"; };
+		04F4611626C4030D007CEEAB /* component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = component_base.hpp; sourceTree = "<group>"; };
+		04F4611826C4030D007CEEAB /* weight_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = weight_base.hpp; sourceTree = "<group>"; };
+		04F4611926C4030D007CEEAB /* root_bone_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = root_bone_base.hpp; sourceTree = "<group>"; };
+		04F4611A26C4030D007CEEAB /* cubic_weight_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_weight_base.hpp; sourceTree = "<group>"; };
+		04F4611B26C4030D007CEEAB /* bone_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bone_base.hpp; sourceTree = "<group>"; };
+		04F4611C26C4030D007CEEAB /* skin_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skin_base.hpp; sourceTree = "<group>"; };
+		04F4611D26C4030D007CEEAB /* tendon_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = tendon_base.hpp; sourceTree = "<group>"; };
+		04F4611E26C4030D007CEEAB /* skeletal_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skeletal_component_base.hpp; sourceTree = "<group>"; };
+		04F4611F26C4030D007CEEAB /* draw_target_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_target_base.hpp; sourceTree = "<group>"; };
+		04F4612026C4030D007CEEAB /* backboard_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = backboard_base.hpp; sourceTree = "<group>"; };
+		04F4612126C4030D007CEEAB /* drawable_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = drawable_base.hpp; sourceTree = "<group>"; };
+		04F4612226C4030D007CEEAB /* backboard.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = backboard.hpp; sourceTree = "<group>"; };
+		04F4612426C4030D007CEEAB /* reader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reader.h; sourceTree = "<group>"; };
+		04F4612626C4030D007CEEAB /* core_color_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_color_type.hpp; sourceTree = "<group>"; };
+		04F4612726C4030D007CEEAB /* core_uint_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_uint_type.hpp; sourceTree = "<group>"; };
+		04F4612826C4030D007CEEAB /* core_double_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_double_type.hpp; sourceTree = "<group>"; };
+		04F4612926C4030D007CEEAB /* core_string_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_string_type.hpp; sourceTree = "<group>"; };
+		04F4612A26C4030D007CEEAB /* core_bool_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_bool_type.hpp; sourceTree = "<group>"; };
+		04F4612B26C4030D007CEEAB /* binary_reader.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = binary_reader.hpp; sourceTree = "<group>"; };
+		04F4612C26C4030D007CEEAB /* status_code.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = status_code.hpp; sourceTree = "<group>"; };
+		04F4612E26C4030D007CEEAB /* targeted_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = targeted_constraint.hpp; sourceTree = "<group>"; };
+		04F4612F26C4030D007CEEAB /* constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = constraint.hpp; sourceTree = "<group>"; };
+		04F4613026C4030D007CEEAB /* ik_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ik_constraint.hpp; sourceTree = "<group>"; };
+		04F4613126C4030D007CEEAB /* transform_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_constraint.hpp; sourceTree = "<group>"; };
+		04F4613226C4030D007CEEAB /* distance_constraint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = distance_constraint.hpp; sourceTree = "<group>"; };
+		04F4613326C4030D007CEEAB /* component_dirt.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = component_dirt.hpp; sourceTree = "<group>"; };
+		04F4613426C4030D007CEEAB /* renderer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = renderer.hpp; sourceTree = "<group>"; };
+		04F4613526C4030D007CEEAB /* draw_target_placement.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_target_placement.hpp; sourceTree = "<group>"; };
+		04F4613726C4030D007CEEAB /* state_transition_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_transition_importer.hpp; sourceTree = "<group>"; };
+		04F4613826C4030D007CEEAB /* state_machine_layer_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer_importer.hpp; sourceTree = "<group>"; };
+		04F4613926C4030D007CEEAB /* keyed_property_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_property_importer.hpp; sourceTree = "<group>"; };
+		04F4613A26C4030D007CEEAB /* keyed_object_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_object_importer.hpp; sourceTree = "<group>"; };
+		04F4613B26C4030D007CEEAB /* linear_animation_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_animation_importer.hpp; sourceTree = "<group>"; };
+		04F4613C26C4030D007CEEAB /* import_stack.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = import_stack.hpp; sourceTree = "<group>"; };
+		04F4613D26C4030D007CEEAB /* layer_state_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = layer_state_importer.hpp; sourceTree = "<group>"; };
+		04F4613E26C4030D007CEEAB /* artboard_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = artboard_importer.hpp; sourceTree = "<group>"; };
+		04F4613F26C4030D007CEEAB /* state_machine_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_importer.hpp; sourceTree = "<group>"; };
+		04F4614026C4030D007CEEAB /* draw_target.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_target.hpp; sourceTree = "<group>"; };
+		04F4614126C4030D007CEEAB /* runtime_header.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = runtime_header.hpp; sourceTree = "<group>"; };
+		04F4614226C4030D007CEEAB /* file.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = file.hpp; sourceTree = "<group>"; };
+		04F4614326C4030D007CEEAB /* container_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = container_component.hpp; sourceTree = "<group>"; };
+		04F4614526C4030D007CEEAB /* transition_bool_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_bool_condition.hpp; sourceTree = "<group>"; };
+		04F4614626C4030D007CEEAB /* cubic_interpolator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_interpolator.hpp; sourceTree = "<group>"; };
+		04F4614726C4030D007CEEAB /* keyed_property.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_property.hpp; sourceTree = "<group>"; };
+		04F4614826C4030D007CEEAB /* state_machine_input.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_input.hpp; sourceTree = "<group>"; };
+		04F4614926C4030D007CEEAB /* layer_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = layer_state.hpp; sourceTree = "<group>"; };
+		04F4614A26C4030D007CEEAB /* state_transition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_transition.hpp; sourceTree = "<group>"; };
+		04F4614B26C4030D007CEEAB /* system_state_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = system_state_instance.hpp; sourceTree = "<group>"; };
+		04F4614C26C4030D007CEEAB /* state_machine_trigger.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_trigger.hpp; sourceTree = "<group>"; };
+		04F4614D26C4030D007CEEAB /* keyframe_id.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_id.hpp; sourceTree = "<group>"; };
+		04F4614E26C4030D007CEEAB /* blend_state_transition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_transition.hpp; sourceTree = "<group>"; };
+		04F4614F26C4030D007CEEAB /* transition_number_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_number_condition.hpp; sourceTree = "<group>"; };
+		04F4615026C4030D007CEEAB /* state_machine_number.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_number.hpp; sourceTree = "<group>"; };
+		04F4615126C4030D007CEEAB /* animation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation.hpp; sourceTree = "<group>"; };
+		04F4615226C4030D007CEEAB /* keyframe.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe.hpp; sourceTree = "<group>"; };
+		04F4615326C4030D007CEEAB /* blend_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state.hpp; sourceTree = "<group>"; };
+		04F4615426C4030D007CEEAB /* state_machine_layer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer.hpp; sourceTree = "<group>"; };
+		04F4615526C4030D007CEEAB /* blend_animation_1d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_1d.hpp; sourceTree = "<group>"; };
+		04F4615626C4030D007CEEAB /* state_machine_layer_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer_component.hpp; sourceTree = "<group>"; };
+		04F4615726C4030D007CEEAB /* blend_state_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_instance.hpp; sourceTree = "<group>"; };
+		04F4615826C4030D007CEEAB /* state_machine_bool.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_bool.hpp; sourceTree = "<group>"; };
+		04F4615926C4030D007CEEAB /* blend_state_1d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_1d.hpp; sourceTree = "<group>"; };
+		04F4615A26C4030D007CEEAB /* state_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_instance.hpp; sourceTree = "<group>"; };
+		04F4615B26C4030D007CEEAB /* keyed_object.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_object.hpp; sourceTree = "<group>"; };
+		04F4615C26C4030D007CEEAB /* state_machine_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_component.hpp; sourceTree = "<group>"; };
+		04F4615D26C4030D007CEEAB /* state_machine.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine.hpp; sourceTree = "<group>"; };
+		04F4615E26C4030D007CEEAB /* blend_state_1d_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_1d_instance.hpp; sourceTree = "<group>"; };
+		04F4615F26C4030D007CEEAB /* state_machine_input_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_input_instance.hpp; sourceTree = "<group>"; };
+		04F4616026C4030D007CEEAB /* transition_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_condition.hpp; sourceTree = "<group>"; };
+		04F4616126C4030D007CEEAB /* transition_value_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_value_condition.hpp; sourceTree = "<group>"; };
+		04F4616226C4030D007CEEAB /* animation_state_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_state_instance.hpp; sourceTree = "<group>"; };
+		04F4616326C4030D007CEEAB /* linear_animation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_animation.hpp; sourceTree = "<group>"; };
+		04F4616426C4030D007CEEAB /* linear_animation_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_animation_instance.hpp; sourceTree = "<group>"; };
+		04F4616526C4030D007CEEAB /* transition_condition_op.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_condition_op.hpp; sourceTree = "<group>"; };
+		04F4616626C4030D007CEEAB /* blend_state_direct_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_direct_instance.hpp; sourceTree = "<group>"; };
+		04F4616726C4030D007CEEAB /* keyframe_double.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_double.hpp; sourceTree = "<group>"; };
+		04F4616826C4030D007CEEAB /* blend_animation_direct.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_direct.hpp; sourceTree = "<group>"; };
+		04F4616926C4030D007CEEAB /* loop.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = loop.hpp; sourceTree = "<group>"; };
+		04F4616A26C4030D007CEEAB /* keyframe_color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_color.hpp; sourceTree = "<group>"; };
+		04F4616B26C4030D007CEEAB /* entry_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = entry_state.hpp; sourceTree = "<group>"; };
+		04F4616C26C4030D007CEEAB /* blend_animation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation.hpp; sourceTree = "<group>"; };
+		04F4616D26C4030D007CEEAB /* state_machine_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_instance.hpp; sourceTree = "<group>"; };
+		04F4616E26C4030D007CEEAB /* state_transition_flags.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_transition_flags.hpp; sourceTree = "<group>"; };
+		04F4616F26C4030D007CEEAB /* exit_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = exit_state.hpp; sourceTree = "<group>"; };
+		04F4617026C4030D007CEEAB /* any_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = any_state.hpp; sourceTree = "<group>"; };
+		04F4617126C4030D007CEEAB /* animation_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_state.hpp; sourceTree = "<group>"; };
+		04F4617226C4030D007CEEAB /* blend_state_direct.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_direct.hpp; sourceTree = "<group>"; };
+		04F4617326C4030D007CEEAB /* transition_trigger_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_trigger_condition.hpp; sourceTree = "<group>"; };
+		04F4617426C4030D007CEEAB /* transform_space.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_space.hpp; sourceTree = "<group>"; };
+		04F4617626C4030D007CEEAB /* straight_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = straight_vertex.hpp; sourceTree = "<group>"; };
+		04F4617826C4030D007CEEAB /* stroke_cap.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_cap.hpp; sourceTree = "<group>"; };
+		04F4617926C4030D007CEEAB /* gradient_stop.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = gradient_stop.hpp; sourceTree = "<group>"; };
+		04F4617A26C4030D007CEEAB /* stroke.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke.hpp; sourceTree = "<group>"; };
+		04F4617B26C4030D007CEEAB /* shape_paint_mutator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint_mutator.hpp; sourceTree = "<group>"; };
+		04F4617C26C4030D007CEEAB /* blend_mode.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_mode.hpp; sourceTree = "<group>"; };
+		04F4617D26C4030D007CEEAB /* shape_paint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint.hpp; sourceTree = "<group>"; };
+		04F4617E26C4030D007CEEAB /* stroke_join.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_join.hpp; sourceTree = "<group>"; };
+		04F4617F26C4030D007CEEAB /* fill.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fill.hpp; sourceTree = "<group>"; };
+		04F4618026C4030D007CEEAB /* radial_gradient.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = radial_gradient.hpp; sourceTree = "<group>"; };
+		04F4618126C4030D007CEEAB /* trim_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = trim_path.hpp; sourceTree = "<group>"; };
+		04F4618226C4030D007CEEAB /* color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = color.hpp; sourceTree = "<group>"; };
+		04F4618326C4030D007CEEAB /* solid_color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = solid_color.hpp; sourceTree = "<group>"; };
+		04F4618426C4030D007CEEAB /* linear_gradient.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_gradient.hpp; sourceTree = "<group>"; };
+		04F4618526C4030D007CEEAB /* stroke_effect.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_effect.hpp; sourceTree = "<group>"; };
+		04F4618626C4030D007CEEAB /* path_composer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_composer.hpp; sourceTree = "<group>"; };
+		04F4618726C4030D007CEEAB /* shape_paint_container.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint_container.hpp; sourceTree = "<group>"; };
+		04F4618826C4030D007CEEAB /* cubic_mirrored_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_mirrored_vertex.hpp; sourceTree = "<group>"; };
+		04F4618926C4030D007CEEAB /* path_space.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_space.hpp; sourceTree = "<group>"; };
+		04F4618A26C4030D007CEEAB /* ellipse.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ellipse.hpp; sourceTree = "<group>"; };
+		04F4618B26C4030D007CEEAB /* clipping_shape.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = clipping_shape.hpp; sourceTree = "<group>"; };
+		04F4618C26C4030D007CEEAB /* metrics_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = metrics_path.hpp; sourceTree = "<group>"; };
+		04F4618D26C4030D007CEEAB /* cubic_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_vertex.hpp; sourceTree = "<group>"; };
+		04F4618E26C4030D007CEEAB /* shape.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape.hpp; sourceTree = "<group>"; };
+		04F4618F26C4030D007CEEAB /* triangle.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = triangle.hpp; sourceTree = "<group>"; };
+		04F4619026C4030D007CEEAB /* path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path.hpp; sourceTree = "<group>"; };
+		04F4619126C4030D007CEEAB /* polygon.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = polygon.hpp; sourceTree = "<group>"; };
+		04F4619226C4030D007CEEAB /* path_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_vertex.hpp; sourceTree = "<group>"; };
+		04F4619326C4030D007CEEAB /* parametric_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = parametric_path.hpp; sourceTree = "<group>"; };
+		04F4619426C4030D007CEEAB /* rectangle.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = rectangle.hpp; sourceTree = "<group>"; };
+		04F4619526C4030D007CEEAB /* points_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = points_path.hpp; sourceTree = "<group>"; };
+		04F4619626C4030D007CEEAB /* star.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = star.hpp; sourceTree = "<group>"; };
+		04F4619726C4030D007CEEAB /* cubic_asymmetric_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_asymmetric_vertex.hpp; sourceTree = "<group>"; };
+		04F4619826C4030D007CEEAB /* cubic_detached_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_detached_vertex.hpp; sourceTree = "<group>"; };
+		04F4619A26C4030D007CEEAB /* vec2d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = vec2d.hpp; sourceTree = "<group>"; };
+		04F4619B26C4030D007CEEAB /* mat2d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = mat2d.hpp; sourceTree = "<group>"; };
+		04F4619C26C4030D007CEEAB /* aabb.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = aabb.hpp; sourceTree = "<group>"; };
+		04F4619D26C4030D007CEEAB /* color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = color.hpp; sourceTree = "<group>"; };
+		04F4619E26C4030D007CEEAB /* transform_components.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_components.hpp; sourceTree = "<group>"; };
+		04F4619F26C4030D007CEEAB /* circle_constant.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = circle_constant.hpp; sourceTree = "<group>"; };
+		04F461A026C4030D007CEEAB /* command_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = command_path.hpp; sourceTree = "<group>"; };
+		04F461A126C4030D007CEEAB /* component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = component.hpp; sourceTree = "<group>"; };
+		04F461A226C4030D007CEEAB /* node.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = node.hpp; sourceTree = "<group>"; };
+		04F461A326C4030D007CEEAB /* layout.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = layout.hpp; sourceTree = "<group>"; };
+		04F461A426C4030D007CEEAB /* drawable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = drawable.hpp; sourceTree = "<group>"; };
+		04F461A526C4030D007CEEAB /* artboard.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = artboard.hpp; sourceTree = "<group>"; };
+		04F461A626C4030D007CEEAB /* dependency_sorter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = dependency_sorter.hpp; sourceTree = "<group>"; };
+		04F461A726C4030D007CEEAB /* core_context.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_context.hpp; sourceTree = "<group>"; };
+		04F461A926C4030D007CEEAB /* tendon.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = tendon.hpp; sourceTree = "<group>"; };
+		04F461AA26C4030D007CEEAB /* skeletal_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skeletal_component.hpp; sourceTree = "<group>"; };
+		04F461AB26C4030D007CEEAB /* weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = weight.hpp; sourceTree = "<group>"; };
+		04F461AC26C4030D007CEEAB /* skin.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skin.hpp; sourceTree = "<group>"; };
+		04F461AD26C4030D007CEEAB /* root_bone.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = root_bone.hpp; sourceTree = "<group>"; };
+		04F461AE26C4030D007CEEAB /* bone.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bone.hpp; sourceTree = "<group>"; };
+		04F461AF26C4030D007CEEAB /* skinnable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skinnable.hpp; sourceTree = "<group>"; };
+		04F461B026C4030D007CEEAB /* cubic_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_weight.hpp; sourceTree = "<group>"; };
+		04F461B126C4030D007CEEAB /* draw_rules.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_rules.hpp; sourceTree = "<group>"; };
+		04F461B226C4030D007CEEAB /* core.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core.hpp; sourceTree = "<group>"; };
+		04F461B326C4030D007CEEAB /* transform_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_component.hpp; sourceTree = "<group>"; };
 		C9002A1F263C76080011556B /* RiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RiveView.swift; sourceTree = "<group>"; };
 		C9601F29250C25830032AA07 /* RiveRenderer.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RiveRenderer.hpp; sourceTree = "<group>"; };
 		C9601F2A250C25930032AA07 /* RiveRenderer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RiveRenderer.mm; sourceTree = "<group>"; };
-		C9601F2D251004770032AA07 /* vec2d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = vec2d.hpp; sourceTree = "<group>"; };
-		C9601F2E251004770032AA07 /* mat2d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = mat2d.hpp; sourceTree = "<group>"; };
-		C9601F2F251004770032AA07 /* aabb.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = aabb.hpp; sourceTree = "<group>"; };
-		C9601F30251004770032AA07 /* color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = color.hpp; sourceTree = "<group>"; };
-		C9601F31251004770032AA07 /* transform_components.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_components.hpp; sourceTree = "<group>"; };
-		C9601F32251004770032AA07 /* circle_constant.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = circle_constant.hpp; sourceTree = "<group>"; };
-		C9601F33251004770032AA07 /* stroke_effect.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = stroke_effect.hpp; path = shapes/paint/stroke_effect.hpp; sourceTree = "<group>"; };
-		C9601F34251004770032AA07 /* trim_path_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = trim_path_base.hpp; path = generated/shapes/paint/trim_path_base.hpp; sourceTree = "<group>"; };
-		C9601F35251004780032AA07 /* command_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = command_path.hpp; sourceTree = "<group>"; };
-		C9601F36251004780032AA07 /* metrics_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = metrics_path.hpp; path = shapes/metrics_path.hpp; sourceTree = "<group>"; };
-		C9601F38251004780032AA07 /* stroke_cap.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_cap.hpp; sourceTree = "<group>"; };
-		C9601F39251004780032AA07 /* gradient_stop.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = gradient_stop.hpp; sourceTree = "<group>"; };
-		C9601F3A251004780032AA07 /* stroke.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke.hpp; sourceTree = "<group>"; };
-		C9601F3B251004780032AA07 /* shape_paint_mutator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint_mutator.hpp; sourceTree = "<group>"; };
-		C9601F3C251004780032AA07 /* blend_mode.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_mode.hpp; sourceTree = "<group>"; };
-		C9601F3D251004780032AA07 /* shape_paint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint.hpp; sourceTree = "<group>"; };
-		C9601F3E251004780032AA07 /* stroke_join.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_join.hpp; sourceTree = "<group>"; };
-		C9601F3F251004780032AA07 /* fill.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fill.hpp; sourceTree = "<group>"; };
-		C9601F40251004780032AA07 /* radial_gradient.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = radial_gradient.hpp; sourceTree = "<group>"; };
-		C9601F41251004780032AA07 /* trim_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = trim_path.hpp; sourceTree = "<group>"; };
-		C9601F42251004780032AA07 /* color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = color.hpp; sourceTree = "<group>"; };
-		C9601F43251004780032AA07 /* solid_color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = solid_color.hpp; sourceTree = "<group>"; };
-		C9601F44251004780032AA07 /* linear_gradient.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_gradient.hpp; sourceTree = "<group>"; };
-		C9601F45251004780032AA07 /* stroke_effect.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_effect.hpp; sourceTree = "<group>"; };
-		C9601F46251004780032AA07 /* trim_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = trim_path.hpp; path = shapes/paint/trim_path.hpp; sourceTree = "<group>"; };
-		C9601F48251004780032AA07 /* straight_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = straight_vertex.hpp; sourceTree = "<group>"; };
-		C9601F4A251004780032AA07 /* stroke_cap.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_cap.hpp; sourceTree = "<group>"; };
-		C9601F4B251004780032AA07 /* gradient_stop.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = gradient_stop.hpp; sourceTree = "<group>"; };
-		C9601F4C251004780032AA07 /* stroke.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke.hpp; sourceTree = "<group>"; };
-		C9601F4D251004780032AA07 /* shape_paint_mutator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint_mutator.hpp; sourceTree = "<group>"; };
-		C9601F4E251004780032AA07 /* blend_mode.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_mode.hpp; sourceTree = "<group>"; };
-		C9601F4F251004780032AA07 /* shape_paint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint.hpp; sourceTree = "<group>"; };
-		C9601F50251004780032AA07 /* stroke_join.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_join.hpp; sourceTree = "<group>"; };
-		C9601F51251004780032AA07 /* fill.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fill.hpp; sourceTree = "<group>"; };
-		C9601F52251004780032AA07 /* radial_gradient.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = radial_gradient.hpp; sourceTree = "<group>"; };
-		C9601F53251004780032AA07 /* trim_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = trim_path.hpp; sourceTree = "<group>"; };
-		C9601F54251004780032AA07 /* color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = color.hpp; sourceTree = "<group>"; };
-		C9601F55251004780032AA07 /* solid_color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = solid_color.hpp; sourceTree = "<group>"; };
-		C9601F56251004780032AA07 /* linear_gradient.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_gradient.hpp; sourceTree = "<group>"; };
-		C9601F57251004780032AA07 /* stroke_effect.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_effect.hpp; sourceTree = "<group>"; };
-		C9601F58251004780032AA07 /* path_composer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_composer.hpp; sourceTree = "<group>"; };
-		C9601F59251004780032AA07 /* shape_paint_container.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint_container.hpp; sourceTree = "<group>"; };
-		C9601F5A251004780032AA07 /* cubic_mirrored_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_mirrored_vertex.hpp; sourceTree = "<group>"; };
-		C9601F5B251004780032AA07 /* path_space.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_space.hpp; sourceTree = "<group>"; };
-		C9601F5C251004780032AA07 /* ellipse.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ellipse.hpp; sourceTree = "<group>"; };
-		C9601F5D251004780032AA07 /* clipping_shape.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = clipping_shape.hpp; sourceTree = "<group>"; };
-		C9601F5E251004780032AA07 /* metrics_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = metrics_path.hpp; sourceTree = "<group>"; };
-		C9601F5F251004780032AA07 /* cubic_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_vertex.hpp; sourceTree = "<group>"; };
-		C9601F60251004780032AA07 /* shape.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape.hpp; sourceTree = "<group>"; };
-		C9601F61251004780032AA07 /* triangle.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = triangle.hpp; sourceTree = "<group>"; };
-		C9601F62251004780032AA07 /* path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path.hpp; sourceTree = "<group>"; };
-		C9601F63251004780032AA07 /* path_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_vertex.hpp; sourceTree = "<group>"; };
-		C9601F64251004780032AA07 /* parametric_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = parametric_path.hpp; sourceTree = "<group>"; };
-		C9601F65251004780032AA07 /* rectangle.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = rectangle.hpp; sourceTree = "<group>"; };
-		C9601F66251004780032AA07 /* points_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = points_path.hpp; sourceTree = "<group>"; };
-		C9601F67251004780032AA07 /* cubic_asymmetric_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_asymmetric_vertex.hpp; sourceTree = "<group>"; };
-		C9601F68251004780032AA07 /* cubic_detached_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_detached_vertex.hpp; sourceTree = "<group>"; };
 		C9601FA2251004950032AA07 /* trim_path.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = trim_path.cpp; path = shapes/paint/trim_path.cpp; sourceTree = "<group>"; };
 		C9601FA3251004950032AA07 /* metrics_path.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = metrics_path.cpp; sourceTree = "<group>"; };
 		C9601FA5251004950032AA07 /* solid_color.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = solid_color.cpp; sourceTree = "<group>"; };
@@ -588,36 +737,9 @@
 		C9601FAC251004950032AA07 /* shape_paint_mutator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = shape_paint_mutator.cpp; sourceTree = "<group>"; };
 		C9601FAD251004950032AA07 /* gradient_stop.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gradient_stop.cpp; sourceTree = "<group>"; };
 		C9601FAE251004950032AA07 /* stroke.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = stroke.cpp; sourceTree = "<group>"; };
-		C98F296E2513FA8B0076E802 /* keyframe_id.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_id.hpp; sourceTree = "<group>"; };
-		C98F29722513FAAE0076E802 /* draw_rules.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_rules.hpp; sourceTree = "<group>"; };
-		C98F29732513FAAE0076E802 /* draw_target_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = draw_target_base.hpp; path = generated/draw_target_base.hpp; sourceTree = "<group>"; };
-		C98F29742513FAAE0076E802 /* draw_rules_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = draw_rules_base.hpp; path = generated/draw_rules_base.hpp; sourceTree = "<group>"; };
-		C98F29752513FAAE0076E802 /* draw_target_placement.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_target_placement.hpp; sourceTree = "<group>"; };
-		C98F29762513FAAE0076E802 /* draw_target.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_target.hpp; sourceTree = "<group>"; };
-		C98F29772513FAAE0076E802 /* keyframe_id_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = keyframe_id_base.hpp; path = generated/animation/keyframe_id_base.hpp; sourceTree = "<group>"; };
 		C98F29802513FAC30076E802 /* draw_target.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = draw_target.cpp; sourceTree = "<group>"; };
 		C98F29812513FAC30076E802 /* keyframe_id.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = keyframe_id.cpp; path = animation/keyframe_id.cpp; sourceTree = "<group>"; };
 		C98F29822513FAC30076E802 /* draw_rules.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = draw_rules.cpp; sourceTree = "<group>"; };
-		C9A9D9E5265C50930005DB1F /* blend_state_direct_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_direct_instance.hpp; sourceTree = "<group>"; };
-		C9A9D9E6265C50930005DB1F /* blend_state_direct.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_direct.hpp; sourceTree = "<group>"; };
-		C9A9D9E7265C50930005DB1F /* blend_animation_direct.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_direct.hpp; sourceTree = "<group>"; };
-		C9A9D9E8265C50930005DB1F /* blend_animation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation.hpp; sourceTree = "<group>"; };
-		C9A9D9E9265C50930005DB1F /* blend_state_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_instance.hpp; sourceTree = "<group>"; };
-		C9A9D9EA265C50930005DB1F /* blend_state_1d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_1d.hpp; sourceTree = "<group>"; };
-		C9A9D9EB265C50930005DB1F /* blend_animation_1d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_1d.hpp; sourceTree = "<group>"; };
-		C9A9D9EC265C50930005DB1F /* system_state_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = system_state_instance.hpp; sourceTree = "<group>"; };
-		C9A9D9ED265C50930005DB1F /* blend_state_transition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_transition.hpp; sourceTree = "<group>"; };
-		C9A9D9EE265C50930005DB1F /* animation_state_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_state_instance.hpp; sourceTree = "<group>"; };
-		C9A9D9EF265C50930005DB1F /* state_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_instance.hpp; sourceTree = "<group>"; };
-		C9A9D9F0265C50930005DB1F /* blend_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state.hpp; sourceTree = "<group>"; };
-		C9A9D9F1265C50930005DB1F /* blend_state_1d_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_1d_instance.hpp; sourceTree = "<group>"; };
-		C9A9D9FF265C50C90005DB1F /* blend_animation_direct_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_direct_base.hpp; sourceTree = "<group>"; };
-		C9A9DA00265C50C90005DB1F /* blend_state_direct_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_direct_base.hpp; sourceTree = "<group>"; };
-		C9A9DA01265C50C90005DB1F /* blend_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_base.hpp; sourceTree = "<group>"; };
-		C9A9DA02265C50C90005DB1F /* blend_animation_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_base.hpp; sourceTree = "<group>"; };
-		C9A9DA03265C50C90005DB1F /* blend_state_1d_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_1d_base.hpp; sourceTree = "<group>"; };
-		C9A9DA04265C50C90005DB1F /* blend_animation_1d_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_animation_1d_base.hpp; sourceTree = "<group>"; };
-		C9A9DA05265C50CA0005DB1F /* blend_state_transition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_state_transition_base.hpp; sourceTree = "<group>"; };
 		C9A9DA0D265C510F0005DB1F /* blend_animation_direct.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = blend_animation_direct.cpp; sourceTree = "<group>"; };
 		C9A9DA0E265C510F0005DB1F /* blend_state.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = blend_state.cpp; sourceTree = "<group>"; };
 		C9A9DA0F265C510F0005DB1F /* animation_state_instance.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = animation_state_instance.cpp; sourceTree = "<group>"; };
@@ -681,63 +803,8 @@
 		C9A9DA5A265C51A40005DB1F /* root_bone_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = root_bone_base.cpp; sourceTree = "<group>"; };
 		C9A9DA5B265C51A40005DB1F /* cubic_weight_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cubic_weight_base.cpp; sourceTree = "<group>"; };
 		C9A9DA5C265C51A40005DB1F /* node_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = node_base.cpp; sourceTree = "<group>"; };
-		C9AEB7E625C8903C00AE9C43 /* star_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = star_base.hpp; path = generated/shapes/star_base.hpp; sourceTree = "<group>"; };
-		C9AEB7E725C8903C00AE9C43 /* polygon_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = polygon_base.hpp; path = generated/shapes/polygon_base.hpp; sourceTree = "<group>"; };
 		C9AEB7EC25C8904E00AE9C43 /* star.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = star.cpp; path = shapes/star.cpp; sourceTree = "<group>"; };
 		C9AEB7ED25C8904E00AE9C43 /* polygon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = polygon.cpp; path = shapes/polygon.cpp; sourceTree = "<group>"; };
-		C9BD388F263B5D8200696C37 /* state_machine_number_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_number_base.hpp; sourceTree = "<group>"; };
-		C9BD3890263B5D8200696C37 /* state_transition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_transition_base.hpp; sourceTree = "<group>"; };
-		C9BD3891263B5D8200696C37 /* transition_number_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_number_condition_base.hpp; sourceTree = "<group>"; };
-		C9BD3892263B5D8200696C37 /* state_machine_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_component_base.hpp; sourceTree = "<group>"; };
-		C9BD3897263B5D8F00696C37 /* transition_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_condition_base.hpp; sourceTree = "<group>"; };
-		C9BD3898263B5D8F00696C37 /* transition_bool_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_bool_condition_base.hpp; sourceTree = "<group>"; };
-		C9BD3899263B5D8F00696C37 /* transition_trigger_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_trigger_condition_base.hpp; sourceTree = "<group>"; };
-		C9BD389A263B5D8F00696C37 /* state_machine_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_base.hpp; sourceTree = "<group>"; };
-		C9BD389B263B5D8F00696C37 /* layer_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = layer_state_base.hpp; sourceTree = "<group>"; };
-		C9BD389C263B5D9000696C37 /* state_machine_layer_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer_base.hpp; sourceTree = "<group>"; };
-		C9BD389D263B5D9000696C37 /* state_machine_input_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_input_base.hpp; sourceTree = "<group>"; };
-		C9BD389E263B5D9000696C37 /* transition_value_condition_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_value_condition_base.hpp; sourceTree = "<group>"; };
-		C9BD389F263B5D9000696C37 /* state_machine_trigger_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_trigger_base.hpp; sourceTree = "<group>"; };
-		C9BD38A0263B5D9000696C37 /* state_machine_bool_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_bool_base.hpp; sourceTree = "<group>"; };
-		C9BD38A1263B5D9000696C37 /* entry_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = entry_state_base.hpp; sourceTree = "<group>"; };
-		C9BD38A2263B5D9000696C37 /* any_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = any_state_base.hpp; sourceTree = "<group>"; };
-		C9BD38A3263B5D9000696C37 /* exit_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = exit_state_base.hpp; sourceTree = "<group>"; };
-		C9BD38A4263B5D9000696C37 /* state_machine_layer_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer_component_base.hpp; sourceTree = "<group>"; };
-		C9BD38B3263B5DAE00696C37 /* animation_state_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_state_base.hpp; sourceTree = "<group>"; };
-		C9BD38B5263B5DD400696C37 /* polygon.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = polygon.hpp; sourceTree = "<group>"; };
-		C9BD38B6263B5DD400696C37 /* star.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = star.hpp; sourceTree = "<group>"; };
-		C9BD38BA263B5E0D00696C37 /* state_transition_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_transition_importer.hpp; sourceTree = "<group>"; };
-		C9BD38BB263B5E0D00696C37 /* state_machine_layer_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer_importer.hpp; sourceTree = "<group>"; };
-		C9BD38BC263B5E0D00696C37 /* keyed_property_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_property_importer.hpp; sourceTree = "<group>"; };
-		C9BD38BD263B5E0D00696C37 /* keyed_object_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_object_importer.hpp; sourceTree = "<group>"; };
-		C9BD38BE263B5E0D00696C37 /* linear_animation_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_animation_importer.hpp; sourceTree = "<group>"; };
-		C9BD38BF263B5E0D00696C37 /* import_stack.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = import_stack.hpp; sourceTree = "<group>"; };
-		C9BD38C0263B5E0D00696C37 /* layer_state_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = layer_state_importer.hpp; sourceTree = "<group>"; };
-		C9BD38C1263B5E0D00696C37 /* artboard_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = artboard_importer.hpp; sourceTree = "<group>"; };
-		C9BD38C2263B5E0D00696C37 /* state_machine_importer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_importer.hpp; sourceTree = "<group>"; };
-		C9BD38CC263B5E4000696C37 /* transition_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_condition.hpp; sourceTree = "<group>"; };
-		C9BD38CD263B5E4000696C37 /* state_transition_flags.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_transition_flags.hpp; sourceTree = "<group>"; };
-		C9BD38CE263B5E4000696C37 /* entry_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = entry_state.hpp; sourceTree = "<group>"; };
-		C9BD38CF263B5E4000696C37 /* state_machine_layer_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer_component.hpp; sourceTree = "<group>"; };
-		C9BD38D0263B5E4000696C37 /* transition_value_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_value_condition.hpp; sourceTree = "<group>"; };
-		C9BD38D1263B5E4000696C37 /* transition_bool_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_bool_condition.hpp; sourceTree = "<group>"; };
-		C9BD38D2263B5E4000696C37 /* state_machine_bool.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_bool.hpp; sourceTree = "<group>"; };
-		C9BD38D3263B5E4000696C37 /* animation_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_state.hpp; sourceTree = "<group>"; };
-		C9BD38D4263B5E4000696C37 /* state_machine_trigger.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_trigger.hpp; sourceTree = "<group>"; };
-		C9BD38D5263B5E4000696C37 /* state_machine_number.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_number.hpp; sourceTree = "<group>"; };
-		C9BD38D6263B5E4000696C37 /* state_machine.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine.hpp; sourceTree = "<group>"; };
-		C9BD38D7263B5E4000696C37 /* state_transition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_transition.hpp; sourceTree = "<group>"; };
-		C9BD38D8263B5E4000696C37 /* any_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = any_state.hpp; sourceTree = "<group>"; };
-		C9BD38D9263B5E4000696C37 /* state_machine_input.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_input.hpp; sourceTree = "<group>"; };
-		C9BD38DA263B5E4000696C37 /* state_machine_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_component.hpp; sourceTree = "<group>"; };
-		C9BD38DB263B5E4000696C37 /* transition_condition_op.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_condition_op.hpp; sourceTree = "<group>"; };
-		C9BD38DC263B5E4000696C37 /* transition_trigger_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_trigger_condition.hpp; sourceTree = "<group>"; };
-		C9BD38DD263B5E4000696C37 /* state_machine_input_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_input_instance.hpp; sourceTree = "<group>"; };
-		C9BD38DE263B5E4000696C37 /* transition_number_condition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transition_number_condition.hpp; sourceTree = "<group>"; };
-		C9BD38DF263B5E4000696C37 /* exit_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = exit_state.hpp; sourceTree = "<group>"; };
-		C9BD38E0263B5E4000696C37 /* layer_state.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = layer_state.hpp; sourceTree = "<group>"; };
-		C9BD38E1263B5E4000696C37 /* state_machine_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_instance.hpp; sourceTree = "<group>"; };
-		C9BD38E2263B5E4000696C37 /* state_machine_layer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = state_machine_layer.hpp; sourceTree = "<group>"; };
 		C9BD38FB263B5E7600696C37 /* artboard_importer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = artboard_importer.cpp; sourceTree = "<group>"; };
 		C9BD38FC263B5E7600696C37 /* state_machine_importer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = state_machine_importer.cpp; sourceTree = "<group>"; };
 		C9BD38FD263B5E7600696C37 /* linear_animation_importer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = linear_animation_importer.cpp; sourceTree = "<group>"; };
@@ -820,127 +887,6 @@
 		C9C740AA24FC4F0400EF9516 /* weight.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = weight.cpp; sourceTree = "<group>"; };
 		C9C740AB24FC4F0400EF9516 /* skin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = skin.cpp; sourceTree = "<group>"; };
 		C9C740AC24FC4F0400EF9516 /* tendon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tendon.cpp; sourceTree = "<group>"; };
-		C9C740AF24FC4F0400EF9516 /* core_registry.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_registry.hpp; sourceTree = "<group>"; };
-		C9C740B024FC4F0400EF9516 /* node_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = node_base.hpp; sourceTree = "<group>"; };
-		C9C740B124FC4F0400EF9516 /* transform_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_component_base.hpp; sourceTree = "<group>"; };
-		C9C740B224FC4F0400EF9516 /* artboard_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = artboard_base.hpp; sourceTree = "<group>"; };
-		C9C740B424FC4F0400EF9516 /* keyframe_color_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_color_base.hpp; sourceTree = "<group>"; };
-		C9C740B524FC4F0400EF9516 /* keyed_property_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_property_base.hpp; sourceTree = "<group>"; };
-		C9C740B624FC4F0400EF9516 /* keyframe_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_base.hpp; sourceTree = "<group>"; };
-		C9C740B724FC4F0400EF9516 /* animation_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation_base.hpp; sourceTree = "<group>"; };
-		C9C740B824FC4F0400EF9516 /* cubic_interpolator_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_interpolator_base.hpp; sourceTree = "<group>"; };
-		C9C740BB24FC4F0400EF9516 /* linear_animation_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_animation_base.hpp; sourceTree = "<group>"; };
-		C9C740BC24FC4F0400EF9516 /* keyed_object_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_object_base.hpp; sourceTree = "<group>"; };
-		C9C740BD24FC4F0400EF9516 /* keyframe_double_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_double_base.hpp; sourceTree = "<group>"; };
-		C9C740C024FC4F0400EF9516 /* linear_gradient_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_gradient_base.hpp; sourceTree = "<group>"; };
-		C9C740C124FC4F0400EF9516 /* stroke_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_base.hpp; sourceTree = "<group>"; };
-		C9C740C224FC4F0400EF9516 /* fill_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fill_base.hpp; sourceTree = "<group>"; };
-		C9C740C324FC4F0400EF9516 /* shape_paint_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint_base.hpp; sourceTree = "<group>"; };
-		C9C740C424FC4F0400EF9516 /* solid_color_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = solid_color_base.hpp; sourceTree = "<group>"; };
-		C9C740C524FC4F0400EF9516 /* radial_gradient_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = radial_gradient_base.hpp; sourceTree = "<group>"; };
-		C9C740C624FC4F0400EF9516 /* gradient_stop_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = gradient_stop_base.hpp; sourceTree = "<group>"; };
-		C9C740C724FC4F0400EF9516 /* parametric_path_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = parametric_path_base.hpp; sourceTree = "<group>"; };
-		C9C740C824FC4F0400EF9516 /* cubic_asymmetric_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_asymmetric_vertex_base.hpp; sourceTree = "<group>"; };
-		C9C740C924FC4F0400EF9516 /* cubic_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_vertex_base.hpp; sourceTree = "<group>"; };
-		C9C740CA24FC4F0400EF9516 /* ellipse_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ellipse_base.hpp; sourceTree = "<group>"; };
-		C9C740CB24FC4F0400EF9516 /* path_composer_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_composer_base.hpp; sourceTree = "<group>"; };
-		C9C740CC24FC4F0400EF9516 /* points_path_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = points_path_base.hpp; sourceTree = "<group>"; };
-		C9C740CD24FC4F0400EF9516 /* triangle_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = triangle_base.hpp; sourceTree = "<group>"; };
-		C9C740CE24FC4F0400EF9516 /* shape_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_base.hpp; sourceTree = "<group>"; };
-		C9C740CF24FC4F0400EF9516 /* rectangle_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = rectangle_base.hpp; sourceTree = "<group>"; };
-		C9C740D024FC4F0400EF9516 /* cubic_mirrored_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_mirrored_vertex_base.hpp; sourceTree = "<group>"; };
-		C9C740D124FC4F0400EF9516 /* straight_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = straight_vertex_base.hpp; sourceTree = "<group>"; };
-		C9C740D224FC4F0400EF9516 /* path_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_base.hpp; sourceTree = "<group>"; };
-		C9C740D324FC4F0400EF9516 /* cubic_detached_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_detached_vertex_base.hpp; sourceTree = "<group>"; };
-		C9C740D424FC4F0400EF9516 /* clipping_shape_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = clipping_shape_base.hpp; sourceTree = "<group>"; };
-		C9C740D524FC4F0400EF9516 /* path_vertex_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_vertex_base.hpp; sourceTree = "<group>"; };
-		C9C740D624FC4F0400EF9516 /* container_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = container_component_base.hpp; sourceTree = "<group>"; };
-		C9C740D724FC4F0400EF9516 /* component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = component_base.hpp; sourceTree = "<group>"; };
-		C9C740D924FC4F0400EF9516 /* weight_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = weight_base.hpp; sourceTree = "<group>"; };
-		C9C740DA24FC4F0400EF9516 /* root_bone_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = root_bone_base.hpp; sourceTree = "<group>"; };
-		C9C740DB24FC4F0400EF9516 /* cubic_weight_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_weight_base.hpp; sourceTree = "<group>"; };
-		C9C740DC24FC4F0400EF9516 /* bone_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bone_base.hpp; sourceTree = "<group>"; };
-		C9C740DD24FC4F0400EF9516 /* skin_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skin_base.hpp; sourceTree = "<group>"; };
-		C9C740DE24FC4F0400EF9516 /* tendon_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = tendon_base.hpp; sourceTree = "<group>"; };
-		C9C740DF24FC4F0400EF9516 /* skeletal_component_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skeletal_component_base.hpp; sourceTree = "<group>"; };
-		C9C740E024FC4F0400EF9516 /* backboard_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = backboard_base.hpp; sourceTree = "<group>"; };
-		C9C740E124FC4F0400EF9516 /* drawable_base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = drawable_base.hpp; sourceTree = "<group>"; };
-		C9C740E224FC4F0400EF9516 /* backboard.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = backboard.hpp; sourceTree = "<group>"; };
-		C9C740E424FC4F0400EF9516 /* reader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reader.h; sourceTree = "<group>"; };
-		C9C740E624FC4F0400EF9516 /* core_color_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_color_type.hpp; sourceTree = "<group>"; };
-		C9C740E724FC4F0400EF9516 /* core_uint_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_uint_type.hpp; sourceTree = "<group>"; };
-		C9C740E824FC4F0400EF9516 /* core_double_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_double_type.hpp; sourceTree = "<group>"; };
-		C9C740E924FC4F0400EF9516 /* core_string_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_string_type.hpp; sourceTree = "<group>"; };
-		C9C740EA24FC4F0400EF9516 /* core_bool_type.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_bool_type.hpp; sourceTree = "<group>"; };
-		C9C740EB24FC4F0400EF9516 /* binary_reader.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = binary_reader.hpp; sourceTree = "<group>"; };
-		C9C740EC24FC4F0400EF9516 /* status_code.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = status_code.hpp; sourceTree = "<group>"; };
-		C9C740ED24FC4F0400EF9516 /* component_dirt.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = component_dirt.hpp; sourceTree = "<group>"; };
-		C9C740EE24FC4F0400EF9516 /* renderer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = renderer.hpp; sourceTree = "<group>"; };
-		C9C740EF24FC4F0400EF9516 /* runtime_header.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = runtime_header.hpp; sourceTree = "<group>"; };
-		C9C740F024FC4F0400EF9516 /* file.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = file.hpp; sourceTree = "<group>"; };
-		C9C740F124FC4F0400EF9516 /* container_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = container_component.hpp; sourceTree = "<group>"; };
-		C9C740F324FC4F0500EF9516 /* cubic_interpolator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_interpolator.hpp; sourceTree = "<group>"; };
-		C9C740F424FC4F0500EF9516 /* keyed_property.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_property.hpp; sourceTree = "<group>"; };
-		C9C740F724FC4F0500EF9516 /* animation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = animation.hpp; sourceTree = "<group>"; };
-		C9C740F824FC4F0500EF9516 /* keyframe.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe.hpp; sourceTree = "<group>"; };
-		C9C740F924FC4F0500EF9516 /* keyed_object.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyed_object.hpp; sourceTree = "<group>"; };
-		C9C740FA24FC4F0500EF9516 /* linear_animation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_animation.hpp; sourceTree = "<group>"; };
-		C9C740FB24FC4F0500EF9516 /* linear_animation_instance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_animation_instance.hpp; sourceTree = "<group>"; };
-		C9C740FC24FC4F0500EF9516 /* keyframe_double.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_double.hpp; sourceTree = "<group>"; };
-		C9C740FD24FC4F0500EF9516 /* loop.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = loop.hpp; sourceTree = "<group>"; };
-		C9C740FE24FC4F0500EF9516 /* keyframe_color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keyframe_color.hpp; sourceTree = "<group>"; };
-		C9C7410024FC4F0500EF9516 /* straight_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = straight_vertex.hpp; sourceTree = "<group>"; };
-		C9C7410224FC4F0500EF9516 /* stroke_cap.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_cap.hpp; sourceTree = "<group>"; };
-		C9C7410324FC4F0500EF9516 /* gradient_stop.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = gradient_stop.hpp; sourceTree = "<group>"; };
-		C9C7410424FC4F0500EF9516 /* stroke.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke.hpp; sourceTree = "<group>"; };
-		C9C7410524FC4F0500EF9516 /* shape_paint_mutator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint_mutator.hpp; sourceTree = "<group>"; };
-		C9C7410624FC4F0500EF9516 /* blend_mode.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = blend_mode.hpp; sourceTree = "<group>"; };
-		C9C7410724FC4F0500EF9516 /* shape_paint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint.hpp; sourceTree = "<group>"; };
-		C9C7410824FC4F0500EF9516 /* stroke_join.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = stroke_join.hpp; sourceTree = "<group>"; };
-		C9C7410924FC4F0500EF9516 /* fill.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fill.hpp; sourceTree = "<group>"; };
-		C9C7410A24FC4F0500EF9516 /* radial_gradient.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = radial_gradient.hpp; sourceTree = "<group>"; };
-		C9C7410B24FC4F0500EF9516 /* color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = color.hpp; sourceTree = "<group>"; };
-		C9C7410C24FC4F0500EF9516 /* solid_color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = solid_color.hpp; sourceTree = "<group>"; };
-		C9C7410D24FC4F0500EF9516 /* linear_gradient.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = linear_gradient.hpp; sourceTree = "<group>"; };
-		C9C7410E24FC4F0500EF9516 /* path_composer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_composer.hpp; sourceTree = "<group>"; };
-		C9C7410F24FC4F0500EF9516 /* shape_paint_container.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape_paint_container.hpp; sourceTree = "<group>"; };
-		C9C7411024FC4F0500EF9516 /* cubic_mirrored_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_mirrored_vertex.hpp; sourceTree = "<group>"; };
-		C9C7411124FC4F0500EF9516 /* path_space.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_space.hpp; sourceTree = "<group>"; };
-		C9C7411224FC4F0500EF9516 /* ellipse.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ellipse.hpp; sourceTree = "<group>"; };
-		C9C7411324FC4F0500EF9516 /* clipping_shape.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = clipping_shape.hpp; sourceTree = "<group>"; };
-		C9C7411424FC4F0500EF9516 /* cubic_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_vertex.hpp; sourceTree = "<group>"; };
-		C9C7411524FC4F0500EF9516 /* shape.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shape.hpp; sourceTree = "<group>"; };
-		C9C7411624FC4F0500EF9516 /* triangle.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = triangle.hpp; sourceTree = "<group>"; };
-		C9C7411724FC4F0500EF9516 /* path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path.hpp; sourceTree = "<group>"; };
-		C9C7411824FC4F0500EF9516 /* path_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = path_vertex.hpp; sourceTree = "<group>"; };
-		C9C7411924FC4F0500EF9516 /* parametric_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = parametric_path.hpp; sourceTree = "<group>"; };
-		C9C7411A24FC4F0500EF9516 /* rectangle.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = rectangle.hpp; sourceTree = "<group>"; };
-		C9C7411B24FC4F0500EF9516 /* points_path.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = points_path.hpp; sourceTree = "<group>"; };
-		C9C7411C24FC4F0500EF9516 /* cubic_asymmetric_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_asymmetric_vertex.hpp; sourceTree = "<group>"; };
-		C9C7411D24FC4F0500EF9516 /* cubic_detached_vertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_detached_vertex.hpp; sourceTree = "<group>"; };
-		C9C7411F24FC4F0500EF9516 /* vec2d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = vec2d.hpp; sourceTree = "<group>"; };
-		C9C7412024FC4F0500EF9516 /* mat2d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = mat2d.hpp; sourceTree = "<group>"; };
-		C9C7412124FC4F0500EF9516 /* aabb.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = aabb.hpp; sourceTree = "<group>"; };
-		C9C7412224FC4F0500EF9516 /* color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = color.hpp; sourceTree = "<group>"; };
-		C9C7412324FC4F0500EF9516 /* transform_components.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_components.hpp; sourceTree = "<group>"; };
-		C9C7412424FC4F0500EF9516 /* circle_constant.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = circle_constant.hpp; sourceTree = "<group>"; };
-		C9C7412524FC4F0500EF9516 /* component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = component.hpp; sourceTree = "<group>"; };
-		C9C7412624FC4F0500EF9516 /* node.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = node.hpp; sourceTree = "<group>"; };
-		C9C7412724FC4F0500EF9516 /* layout.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = layout.hpp; sourceTree = "<group>"; };
-		C9C7412824FC4F0500EF9516 /* drawable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = drawable.hpp; sourceTree = "<group>"; };
-		C9C7412924FC4F0500EF9516 /* artboard.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = artboard.hpp; sourceTree = "<group>"; };
-		C9C7412A24FC4F0500EF9516 /* dependency_sorter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = dependency_sorter.hpp; sourceTree = "<group>"; };
-		C9C7412B24FC4F0500EF9516 /* core_context.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core_context.hpp; sourceTree = "<group>"; };
-		C9C7412D24FC4F0500EF9516 /* tendon.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = tendon.hpp; sourceTree = "<group>"; };
-		C9C7412E24FC4F0500EF9516 /* skeletal_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skeletal_component.hpp; sourceTree = "<group>"; };
-		C9C7412F24FC4F0500EF9516 /* weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = weight.hpp; sourceTree = "<group>"; };
-		C9C7413024FC4F0500EF9516 /* skin.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skin.hpp; sourceTree = "<group>"; };
-		C9C7413124FC4F0500EF9516 /* root_bone.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = root_bone.hpp; sourceTree = "<group>"; };
-		C9C7413224FC4F0500EF9516 /* bone.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = bone.hpp; sourceTree = "<group>"; };
-		C9C7413324FC4F0500EF9516 /* skinnable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = skinnable.hpp; sourceTree = "<group>"; };
-		C9C7413424FC4F0500EF9516 /* cubic_weight.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cubic_weight.hpp; sourceTree = "<group>"; };
-		C9C7413524FC4F0500EF9516 /* core.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = core.hpp; sourceTree = "<group>"; };
-		C9C7413624FC4F0500EF9516 /* transform_component.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transform_component.hpp; sourceTree = "<group>"; };
 		C9C741F224FC510200EF9516 /* Rive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Rive.h; sourceTree = "<group>"; };
 		C9C741F324FC510200EF9516 /* Rive.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Rive.mm; sourceTree = "<group>"; };
 		C9CE8252263B716F00F98DDB /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/System/iOSSupport/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -1033,112 +979,358 @@
 			path = constraints;
 			sourceTree = "<group>";
 		};
-		04F1C93426A84BB400CEE6BE /* constraints */ = {
+		04F460A726C401B9007CEEAB /* include */ = {
 			isa = PBXGroup;
 			children = (
-				0450446326B3F74A007B25CA /* distance_constraint.hpp */,
-				0450446226B3F74A007B25CA /* transform_constraint.hpp */,
-				04F1C93526A84BB400CEE6BE /* targeted_constraint.hpp */,
-				04F1C93626A84BB400CEE6BE /* constraint.hpp */,
-				04F1C93726A84BB400CEE6BE /* ik_constraint.hpp */,
+				04F460CA26C4030C007CEEAB /* rive */,
+			);
+			name = include;
+			sourceTree = "<group>";
+		};
+		04F460CA26C4030C007CEEAB /* rive */ = {
+			isa = PBXGroup;
+			children = (
+				04F460CB26C4030C007CEEAB /* generated */,
+				04F4612226C4030D007CEEAB /* backboard.hpp */,
+				04F4612326C4030D007CEEAB /* core */,
+				04F4612C26C4030D007CEEAB /* status_code.hpp */,
+				04F4612D26C4030D007CEEAB /* constraints */,
+				04F4613326C4030D007CEEAB /* component_dirt.hpp */,
+				04F4613426C4030D007CEEAB /* renderer.hpp */,
+				04F4613526C4030D007CEEAB /* draw_target_placement.hpp */,
+				04F4613626C4030D007CEEAB /* importers */,
+				04F4614026C4030D007CEEAB /* draw_target.hpp */,
+				04F4614126C4030D007CEEAB /* runtime_header.hpp */,
+				04F4614226C4030D007CEEAB /* file.hpp */,
+				04F4614326C4030D007CEEAB /* container_component.hpp */,
+				04F4614426C4030D007CEEAB /* animation */,
+				04F4617426C4030D007CEEAB /* transform_space.hpp */,
+				04F4617526C4030D007CEEAB /* shapes */,
+				04F4619926C4030D007CEEAB /* math */,
+				04F461A026C4030D007CEEAB /* command_path.hpp */,
+				04F461A126C4030D007CEEAB /* component.hpp */,
+				04F461A226C4030D007CEEAB /* node.hpp */,
+				04F461A326C4030D007CEEAB /* layout.hpp */,
+				04F461A426C4030D007CEEAB /* drawable.hpp */,
+				04F461A526C4030D007CEEAB /* artboard.hpp */,
+				04F461A626C4030D007CEEAB /* dependency_sorter.hpp */,
+				04F461A726C4030D007CEEAB /* core_context.hpp */,
+				04F461A826C4030D007CEEAB /* bones */,
+				04F461B126C4030D007CEEAB /* draw_rules.hpp */,
+				04F461B226C4030D007CEEAB /* core.hpp */,
+				04F461B326C4030D007CEEAB /* transform_component.hpp */,
+			);
+			name = rive;
+			path = "submodules/rive-cpp/include/rive";
+			sourceTree = "<group>";
+		};
+		04F460CB26C4030C007CEEAB /* generated */ = {
+			isa = PBXGroup;
+			children = (
+				04F460CC26C4030C007CEEAB /* core_registry.hpp */,
+				04F460CD26C4030C007CEEAB /* node_base.hpp */,
+				04F460CE26C4030C007CEEAB /* transform_component_base.hpp */,
+				04F460CF26C4030C007CEEAB /* constraints */,
+				04F460D526C4030C007CEEAB /* artboard_base.hpp */,
+				04F460D626C4030C007CEEAB /* draw_rules_base.hpp */,
+				04F460D726C4030C007CEEAB /* animation */,
+				04F460FB26C4030D007CEEAB /* shapes */,
+				04F4611526C4030D007CEEAB /* container_component_base.hpp */,
+				04F4611626C4030D007CEEAB /* component_base.hpp */,
+				04F4611726C4030D007CEEAB /* bones */,
+				04F4611F26C4030D007CEEAB /* draw_target_base.hpp */,
+				04F4612026C4030D007CEEAB /* backboard_base.hpp */,
+				04F4612126C4030D007CEEAB /* drawable_base.hpp */,
+			);
+			path = generated;
+			sourceTree = "<group>";
+		};
+		04F460CF26C4030C007CEEAB /* constraints */ = {
+			isa = PBXGroup;
+			children = (
+				04F460D026C4030C007CEEAB /* constraint_base.hpp */,
+				04F460D126C4030C007CEEAB /* targeted_constraint_base.hpp */,
+				04F460D226C4030C007CEEAB /* ik_constraint_base.hpp */,
+				04F460D326C4030C007CEEAB /* transform_constraint_base.hpp */,
+				04F460D426C4030C007CEEAB /* distance_constraint_base.hpp */,
 			);
 			path = constraints;
 			sourceTree = "<group>";
 		};
-		04F1C93B26A84BD900CEE6BE /* constraints */ = {
+		04F460D726C4030C007CEEAB /* animation */ = {
 			isa = PBXGroup;
 			children = (
-				0450446626B3F7A5007B25CA /* distance_constraint_base.hpp */,
-				0450446726B3F7A5007B25CA /* transform_constraint_base.hpp */,
-				04F1C93C26A84BD900CEE6BE /* constraint_base.hpp */,
-				04F1C93D26A84BD900CEE6BE /* targeted_constraint_base.hpp */,
-				04F1C93E26A84BD900CEE6BE /* ik_constraint_base.hpp */,
+				04F460D826C4030C007CEEAB /* blend_animation_base.hpp */,
+				04F460D926C4030C007CEEAB /* keyframe_color_base.hpp */,
+				04F460DA26C4030C007CEEAB /* keyed_property_base.hpp */,
+				04F460DB26C4030C007CEEAB /* keyframe_base.hpp */,
+				04F460DC26C4030C007CEEAB /* animation_state_base.hpp */,
+				04F460DD26C4030C007CEEAB /* animation_base.hpp */,
+				04F460DE26C4030C007CEEAB /* blend_state_base.hpp */,
+				04F460DF26C4030C007CEEAB /* transition_number_condition_base.hpp */,
+				04F460E026C4030C007CEEAB /* cubic_interpolator_base.hpp */,
+				04F460E126C4030C007CEEAB /* linear_animation_base.hpp */,
+				04F460E226C4030C007CEEAB /* entry_state_base.hpp */,
+				04F460E326C4030C007CEEAB /* layer_state_base.hpp */,
+				04F460E426C4030C007CEEAB /* state_machine_layer_component_base.hpp */,
+				04F460E526C4030C007CEEAB /* blend_state_direct_base.hpp */,
+				04F460E626C4030C007CEEAB /* state_machine_layer_base.hpp */,
+				04F460E726C4030C007CEEAB /* keyframe_id_base.hpp */,
+				04F460E826C4030C007CEEAB /* blend_animation_1d_base.hpp */,
+				04F460E926C4030C007CEEAB /* keyed_object_base.hpp */,
+				04F460EA26C4030C007CEEAB /* transition_value_condition_base.hpp */,
+				04F460EB26C4030C007CEEAB /* state_machine_number_base.hpp */,
+				04F460EC26C4030C007CEEAB /* state_transition_base.hpp */,
+				04F460ED26C4030C007CEEAB /* keyframe_double_base.hpp */,
+				04F460EE26C4030C007CEEAB /* state_machine_bool_base.hpp */,
+				04F460EF26C4030C007CEEAB /* blend_state_transition_base.hpp */,
+				04F460F026C4030C007CEEAB /* blend_animation_direct_base.hpp */,
+				04F460F126C4030C007CEEAB /* transition_bool_condition_base.hpp */,
+				04F460F226C4030C007CEEAB /* transition_trigger_condition_base.hpp */,
+				04F460F326C4030C007CEEAB /* state_machine_component_base.hpp */,
+				04F460F426C4030C007CEEAB /* any_state_base.hpp */,
+				04F460F526C4030C007CEEAB /* transition_condition_base.hpp */,
+				04F460F626C4030C007CEEAB /* state_machine_input_base.hpp */,
+				04F460F726C4030D007CEEAB /* blend_state_1d_base.hpp */,
+				04F460F826C4030D007CEEAB /* state_machine_trigger_base.hpp */,
+				04F460F926C4030D007CEEAB /* state_machine_base.hpp */,
+				04F460FA26C4030D007CEEAB /* exit_state_base.hpp */,
 			);
-			path = constraints;
+			path = animation;
 			sourceTree = "<group>";
 		};
-		C9601F2C251004770032AA07 /* math */ = {
+		04F460FB26C4030D007CEEAB /* shapes */ = {
 			isa = PBXGroup;
 			children = (
-				C9601F2D251004770032AA07 /* vec2d.hpp */,
-				C9601F2E251004770032AA07 /* mat2d.hpp */,
-				C9601F2F251004770032AA07 /* aabb.hpp */,
-				C9601F30251004770032AA07 /* color.hpp */,
-				C9601F31251004770032AA07 /* transform_components.hpp */,
-				C9601F32251004770032AA07 /* circle_constant.hpp */,
-			);
-			path = math;
-			sourceTree = "<group>";
-		};
-		C9601F37251004780032AA07 /* paint */ = {
-			isa = PBXGroup;
-			children = (
-				C9601F38251004780032AA07 /* stroke_cap.hpp */,
-				C9601F39251004780032AA07 /* gradient_stop.hpp */,
-				C9601F3A251004780032AA07 /* stroke.hpp */,
-				C9601F3B251004780032AA07 /* shape_paint_mutator.hpp */,
-				C9601F3C251004780032AA07 /* blend_mode.hpp */,
-				C9601F3D251004780032AA07 /* shape_paint.hpp */,
-				C9601F3E251004780032AA07 /* stroke_join.hpp */,
-				C9601F3F251004780032AA07 /* fill.hpp */,
-				C9601F40251004780032AA07 /* radial_gradient.hpp */,
-				C9601F41251004780032AA07 /* trim_path.hpp */,
-				C9601F42251004780032AA07 /* color.hpp */,
-				C9601F43251004780032AA07 /* solid_color.hpp */,
-				C9601F44251004780032AA07 /* linear_gradient.hpp */,
-				C9601F45251004780032AA07 /* stroke_effect.hpp */,
-			);
-			name = paint;
-			path = shapes/paint;
-			sourceTree = "<group>";
-		};
-		C9601F47251004780032AA07 /* shapes */ = {
-			isa = PBXGroup;
-			children = (
-				C9BD38B5263B5DD400696C37 /* polygon.hpp */,
-				C9BD38B6263B5DD400696C37 /* star.hpp */,
-				C9601F48251004780032AA07 /* straight_vertex.hpp */,
-				C9601F49251004780032AA07 /* paint */,
-				C9601F58251004780032AA07 /* path_composer.hpp */,
-				C9601F59251004780032AA07 /* shape_paint_container.hpp */,
-				C9601F5A251004780032AA07 /* cubic_mirrored_vertex.hpp */,
-				C9601F5B251004780032AA07 /* path_space.hpp */,
-				C9601F5C251004780032AA07 /* ellipse.hpp */,
-				C9601F5D251004780032AA07 /* clipping_shape.hpp */,
-				C9601F5E251004780032AA07 /* metrics_path.hpp */,
-				C9601F5F251004780032AA07 /* cubic_vertex.hpp */,
-				C9601F60251004780032AA07 /* shape.hpp */,
-				C9601F61251004780032AA07 /* triangle.hpp */,
-				C9601F62251004780032AA07 /* path.hpp */,
-				C9601F63251004780032AA07 /* path_vertex.hpp */,
-				C9601F64251004780032AA07 /* parametric_path.hpp */,
-				C9601F65251004780032AA07 /* rectangle.hpp */,
-				C9601F66251004780032AA07 /* points_path.hpp */,
-				C9601F67251004780032AA07 /* cubic_asymmetric_vertex.hpp */,
-				C9601F68251004780032AA07 /* cubic_detached_vertex.hpp */,
+				04F460FC26C4030D007CEEAB /* paint */,
+				04F4610526C4030D007CEEAB /* parametric_path_base.hpp */,
+				04F4610626C4030D007CEEAB /* cubic_asymmetric_vertex_base.hpp */,
+				04F4610726C4030D007CEEAB /* cubic_vertex_base.hpp */,
+				04F4610826C4030D007CEEAB /* ellipse_base.hpp */,
+				04F4610926C4030D007CEEAB /* points_path_base.hpp */,
+				04F4610A26C4030D007CEEAB /* triangle_base.hpp */,
+				04F4610B26C4030D007CEEAB /* shape_base.hpp */,
+				04F4610C26C4030D007CEEAB /* rectangle_base.hpp */,
+				04F4610D26C4030D007CEEAB /* cubic_mirrored_vertex_base.hpp */,
+				04F4610E26C4030D007CEEAB /* star_base.hpp */,
+				04F4610F26C4030D007CEEAB /* straight_vertex_base.hpp */,
+				04F4611026C4030D007CEEAB /* path_base.hpp */,
+				04F4611126C4030D007CEEAB /* polygon_base.hpp */,
+				04F4611226C4030D007CEEAB /* cubic_detached_vertex_base.hpp */,
+				04F4611326C4030D007CEEAB /* clipping_shape_base.hpp */,
+				04F4611426C4030D007CEEAB /* path_vertex_base.hpp */,
 			);
 			path = shapes;
 			sourceTree = "<group>";
 		};
-		C9601F49251004780032AA07 /* paint */ = {
+		04F460FC26C4030D007CEEAB /* paint */ = {
 			isa = PBXGroup;
 			children = (
-				C9601F4A251004780032AA07 /* stroke_cap.hpp */,
-				C9601F4B251004780032AA07 /* gradient_stop.hpp */,
-				C9601F4C251004780032AA07 /* stroke.hpp */,
-				C9601F4D251004780032AA07 /* shape_paint_mutator.hpp */,
-				C9601F4E251004780032AA07 /* blend_mode.hpp */,
-				C9601F4F251004780032AA07 /* shape_paint.hpp */,
-				C9601F50251004780032AA07 /* stroke_join.hpp */,
-				C9601F51251004780032AA07 /* fill.hpp */,
-				C9601F52251004780032AA07 /* radial_gradient.hpp */,
-				C9601F53251004780032AA07 /* trim_path.hpp */,
-				C9601F54251004780032AA07 /* color.hpp */,
-				C9601F55251004780032AA07 /* solid_color.hpp */,
-				C9601F56251004780032AA07 /* linear_gradient.hpp */,
-				C9601F57251004780032AA07 /* stroke_effect.hpp */,
+				04F460FD26C4030D007CEEAB /* linear_gradient_base.hpp */,
+				04F460FE26C4030D007CEEAB /* stroke_base.hpp */,
+				04F460FF26C4030D007CEEAB /* fill_base.hpp */,
+				04F4610026C4030D007CEEAB /* shape_paint_base.hpp */,
+				04F4610126C4030D007CEEAB /* solid_color_base.hpp */,
+				04F4610226C4030D007CEEAB /* trim_path_base.hpp */,
+				04F4610326C4030D007CEEAB /* radial_gradient_base.hpp */,
+				04F4610426C4030D007CEEAB /* gradient_stop_base.hpp */,
 			);
 			path = paint;
+			sourceTree = "<group>";
+		};
+		04F4611726C4030D007CEEAB /* bones */ = {
+			isa = PBXGroup;
+			children = (
+				04F4611826C4030D007CEEAB /* weight_base.hpp */,
+				04F4611926C4030D007CEEAB /* root_bone_base.hpp */,
+				04F4611A26C4030D007CEEAB /* cubic_weight_base.hpp */,
+				04F4611B26C4030D007CEEAB /* bone_base.hpp */,
+				04F4611C26C4030D007CEEAB /* skin_base.hpp */,
+				04F4611D26C4030D007CEEAB /* tendon_base.hpp */,
+				04F4611E26C4030D007CEEAB /* skeletal_component_base.hpp */,
+			);
+			path = bones;
+			sourceTree = "<group>";
+		};
+		04F4612326C4030D007CEEAB /* core */ = {
+			isa = PBXGroup;
+			children = (
+				04F4612426C4030D007CEEAB /* reader.h */,
+				04F4612526C4030D007CEEAB /* field_types */,
+				04F4612B26C4030D007CEEAB /* binary_reader.hpp */,
+			);
+			path = core;
+			sourceTree = "<group>";
+		};
+		04F4612526C4030D007CEEAB /* field_types */ = {
+			isa = PBXGroup;
+			children = (
+				04F4612626C4030D007CEEAB /* core_color_type.hpp */,
+				04F4612726C4030D007CEEAB /* core_uint_type.hpp */,
+				04F4612826C4030D007CEEAB /* core_double_type.hpp */,
+				04F4612926C4030D007CEEAB /* core_string_type.hpp */,
+				04F4612A26C4030D007CEEAB /* core_bool_type.hpp */,
+			);
+			path = field_types;
+			sourceTree = "<group>";
+		};
+		04F4612D26C4030D007CEEAB /* constraints */ = {
+			isa = PBXGroup;
+			children = (
+				04F4612E26C4030D007CEEAB /* targeted_constraint.hpp */,
+				04F4612F26C4030D007CEEAB /* constraint.hpp */,
+				04F4613026C4030D007CEEAB /* ik_constraint.hpp */,
+				04F4613126C4030D007CEEAB /* transform_constraint.hpp */,
+				04F4613226C4030D007CEEAB /* distance_constraint.hpp */,
+			);
+			path = constraints;
+			sourceTree = "<group>";
+		};
+		04F4613626C4030D007CEEAB /* importers */ = {
+			isa = PBXGroup;
+			children = (
+				04F4613726C4030D007CEEAB /* state_transition_importer.hpp */,
+				04F4613826C4030D007CEEAB /* state_machine_layer_importer.hpp */,
+				04F4613926C4030D007CEEAB /* keyed_property_importer.hpp */,
+				04F4613A26C4030D007CEEAB /* keyed_object_importer.hpp */,
+				04F4613B26C4030D007CEEAB /* linear_animation_importer.hpp */,
+				04F4613C26C4030D007CEEAB /* import_stack.hpp */,
+				04F4613D26C4030D007CEEAB /* layer_state_importer.hpp */,
+				04F4613E26C4030D007CEEAB /* artboard_importer.hpp */,
+				04F4613F26C4030D007CEEAB /* state_machine_importer.hpp */,
+			);
+			path = importers;
+			sourceTree = "<group>";
+		};
+		04F4614426C4030D007CEEAB /* animation */ = {
+			isa = PBXGroup;
+			children = (
+				04F4614526C4030D007CEEAB /* transition_bool_condition.hpp */,
+				04F4614626C4030D007CEEAB /* cubic_interpolator.hpp */,
+				04F4614726C4030D007CEEAB /* keyed_property.hpp */,
+				04F4614826C4030D007CEEAB /* state_machine_input.hpp */,
+				04F4614926C4030D007CEEAB /* layer_state.hpp */,
+				04F4614A26C4030D007CEEAB /* state_transition.hpp */,
+				04F4614B26C4030D007CEEAB /* system_state_instance.hpp */,
+				04F4614C26C4030D007CEEAB /* state_machine_trigger.hpp */,
+				04F4614D26C4030D007CEEAB /* keyframe_id.hpp */,
+				04F4614E26C4030D007CEEAB /* blend_state_transition.hpp */,
+				04F4614F26C4030D007CEEAB /* transition_number_condition.hpp */,
+				04F4615026C4030D007CEEAB /* state_machine_number.hpp */,
+				04F4615126C4030D007CEEAB /* animation.hpp */,
+				04F4615226C4030D007CEEAB /* keyframe.hpp */,
+				04F4615326C4030D007CEEAB /* blend_state.hpp */,
+				04F4615426C4030D007CEEAB /* state_machine_layer.hpp */,
+				04F4615526C4030D007CEEAB /* blend_animation_1d.hpp */,
+				04F4615626C4030D007CEEAB /* state_machine_layer_component.hpp */,
+				04F4615726C4030D007CEEAB /* blend_state_instance.hpp */,
+				04F4615826C4030D007CEEAB /* state_machine_bool.hpp */,
+				04F4615926C4030D007CEEAB /* blend_state_1d.hpp */,
+				04F4615A26C4030D007CEEAB /* state_instance.hpp */,
+				04F4615B26C4030D007CEEAB /* keyed_object.hpp */,
+				04F4615C26C4030D007CEEAB /* state_machine_component.hpp */,
+				04F4615D26C4030D007CEEAB /* state_machine.hpp */,
+				04F4615E26C4030D007CEEAB /* blend_state_1d_instance.hpp */,
+				04F4615F26C4030D007CEEAB /* state_machine_input_instance.hpp */,
+				04F4616026C4030D007CEEAB /* transition_condition.hpp */,
+				04F4616126C4030D007CEEAB /* transition_value_condition.hpp */,
+				04F4616226C4030D007CEEAB /* animation_state_instance.hpp */,
+				04F4616326C4030D007CEEAB /* linear_animation.hpp */,
+				04F4616426C4030D007CEEAB /* linear_animation_instance.hpp */,
+				04F4616526C4030D007CEEAB /* transition_condition_op.hpp */,
+				04F4616626C4030D007CEEAB /* blend_state_direct_instance.hpp */,
+				04F4616726C4030D007CEEAB /* keyframe_double.hpp */,
+				04F4616826C4030D007CEEAB /* blend_animation_direct.hpp */,
+				04F4616926C4030D007CEEAB /* loop.hpp */,
+				04F4616A26C4030D007CEEAB /* keyframe_color.hpp */,
+				04F4616B26C4030D007CEEAB /* entry_state.hpp */,
+				04F4616C26C4030D007CEEAB /* blend_animation.hpp */,
+				04F4616D26C4030D007CEEAB /* state_machine_instance.hpp */,
+				04F4616E26C4030D007CEEAB /* state_transition_flags.hpp */,
+				04F4616F26C4030D007CEEAB /* exit_state.hpp */,
+				04F4617026C4030D007CEEAB /* any_state.hpp */,
+				04F4617126C4030D007CEEAB /* animation_state.hpp */,
+				04F4617226C4030D007CEEAB /* blend_state_direct.hpp */,
+				04F4617326C4030D007CEEAB /* transition_trigger_condition.hpp */,
+			);
+			path = animation;
+			sourceTree = "<group>";
+		};
+		04F4617526C4030D007CEEAB /* shapes */ = {
+			isa = PBXGroup;
+			children = (
+				04F4617626C4030D007CEEAB /* straight_vertex.hpp */,
+				04F4617726C4030D007CEEAB /* paint */,
+				04F4618626C4030D007CEEAB /* path_composer.hpp */,
+				04F4618726C4030D007CEEAB /* shape_paint_container.hpp */,
+				04F4618826C4030D007CEEAB /* cubic_mirrored_vertex.hpp */,
+				04F4618926C4030D007CEEAB /* path_space.hpp */,
+				04F4618A26C4030D007CEEAB /* ellipse.hpp */,
+				04F4618B26C4030D007CEEAB /* clipping_shape.hpp */,
+				04F4618C26C4030D007CEEAB /* metrics_path.hpp */,
+				04F4618D26C4030D007CEEAB /* cubic_vertex.hpp */,
+				04F4618E26C4030D007CEEAB /* shape.hpp */,
+				04F4618F26C4030D007CEEAB /* triangle.hpp */,
+				04F4619026C4030D007CEEAB /* path.hpp */,
+				04F4619126C4030D007CEEAB /* polygon.hpp */,
+				04F4619226C4030D007CEEAB /* path_vertex.hpp */,
+				04F4619326C4030D007CEEAB /* parametric_path.hpp */,
+				04F4619426C4030D007CEEAB /* rectangle.hpp */,
+				04F4619526C4030D007CEEAB /* points_path.hpp */,
+				04F4619626C4030D007CEEAB /* star.hpp */,
+				04F4619726C4030D007CEEAB /* cubic_asymmetric_vertex.hpp */,
+				04F4619826C4030D007CEEAB /* cubic_detached_vertex.hpp */,
+			);
+			path = shapes;
+			sourceTree = "<group>";
+		};
+		04F4617726C4030D007CEEAB /* paint */ = {
+			isa = PBXGroup;
+			children = (
+				04F4617826C4030D007CEEAB /* stroke_cap.hpp */,
+				04F4617926C4030D007CEEAB /* gradient_stop.hpp */,
+				04F4617A26C4030D007CEEAB /* stroke.hpp */,
+				04F4617B26C4030D007CEEAB /* shape_paint_mutator.hpp */,
+				04F4617C26C4030D007CEEAB /* blend_mode.hpp */,
+				04F4617D26C4030D007CEEAB /* shape_paint.hpp */,
+				04F4617E26C4030D007CEEAB /* stroke_join.hpp */,
+				04F4617F26C4030D007CEEAB /* fill.hpp */,
+				04F4618026C4030D007CEEAB /* radial_gradient.hpp */,
+				04F4618126C4030D007CEEAB /* trim_path.hpp */,
+				04F4618226C4030D007CEEAB /* color.hpp */,
+				04F4618326C4030D007CEEAB /* solid_color.hpp */,
+				04F4618426C4030D007CEEAB /* linear_gradient.hpp */,
+				04F4618526C4030D007CEEAB /* stroke_effect.hpp */,
+			);
+			path = paint;
+			sourceTree = "<group>";
+		};
+		04F4619926C4030D007CEEAB /* math */ = {
+			isa = PBXGroup;
+			children = (
+				04F4619A26C4030D007CEEAB /* vec2d.hpp */,
+				04F4619B26C4030D007CEEAB /* mat2d.hpp */,
+				04F4619C26C4030D007CEEAB /* aabb.hpp */,
+				04F4619D26C4030D007CEEAB /* color.hpp */,
+				04F4619E26C4030D007CEEAB /* transform_components.hpp */,
+				04F4619F26C4030D007CEEAB /* circle_constant.hpp */,
+			);
+			path = math;
+			sourceTree = "<group>";
+		};
+		04F461A826C4030D007CEEAB /* bones */ = {
+			isa = PBXGroup;
+			children = (
+				04F461A926C4030D007CEEAB /* tendon.hpp */,
+				04F461AA26C4030D007CEEAB /* skeletal_component.hpp */,
+				04F461AB26C4030D007CEEAB /* weight.hpp */,
+				04F461AC26C4030D007CEEAB /* skin.hpp */,
+				04F461AD26C4030D007CEEAB /* root_bone.hpp */,
+				04F461AE26C4030D007CEEAB /* bone.hpp */,
+				04F461AF26C4030D007CEEAB /* skinnable.hpp */,
+				04F461B026C4030D007CEEAB /* cubic_weight.hpp */,
+			);
+			path = bones;
 			sourceTree = "<group>";
 		};
 		C9601FA4251004950032AA07 /* paint */ = {
@@ -1255,22 +1447,6 @@
 			path = bones;
 			sourceTree = "<group>";
 		};
-		C9BD38B9263B5E0D00696C37 /* importers */ = {
-			isa = PBXGroup;
-			children = (
-				C9BD38BA263B5E0D00696C37 /* state_transition_importer.hpp */,
-				C9BD38BB263B5E0D00696C37 /* state_machine_layer_importer.hpp */,
-				C9BD38BC263B5E0D00696C37 /* keyed_property_importer.hpp */,
-				C9BD38BD263B5E0D00696C37 /* keyed_object_importer.hpp */,
-				C9BD38BE263B5E0D00696C37 /* linear_animation_importer.hpp */,
-				C9BD38BF263B5E0D00696C37 /* import_stack.hpp */,
-				C9BD38C0263B5E0D00696C37 /* layer_state_importer.hpp */,
-				C9BD38C1263B5E0D00696C37 /* artboard_importer.hpp */,
-				C9BD38C2263B5E0D00696C37 /* state_machine_importer.hpp */,
-			);
-			path = importers;
-			sourceTree = "<group>";
-		};
 		C9BD38FA263B5E7600696C37 /* importers */ = {
 			isa = PBXGroup;
 			children = (
@@ -1367,7 +1543,7 @@
 		C9C7406C24FC4EF400EF9516 /* Rive */ = {
 			isa = PBXGroup;
 			children = (
-				C9C740AD24FC4F0400EF9516 /* include */,
+				04F460A726C401B9007CEEAB /* include */,
 				C9C7406D24FC4F0400EF9516 /* src */,
 			);
 			name = Rive;
@@ -1528,314 +1704,6 @@
 			path = bones;
 			sourceTree = "<group>";
 		};
-		C9C740AD24FC4F0400EF9516 /* include */ = {
-			isa = PBXGroup;
-			children = (
-				0450446A26B3F7C1007B25CA /* transform_space.hpp */,
-				04F1C93426A84BB400CEE6BE /* constraints */,
-				C9BD38B9263B5E0D00696C37 /* importers */,
-				C9AEB7E725C8903C00AE9C43 /* polygon_base.hpp */,
-				C9AEB7E625C8903C00AE9C43 /* star_base.hpp */,
-				C98F29742513FAAE0076E802 /* draw_rules_base.hpp */,
-				C98F29722513FAAE0076E802 /* draw_rules.hpp */,
-				C98F29732513FAAE0076E802 /* draw_target_base.hpp */,
-				C98F29752513FAAE0076E802 /* draw_target_placement.hpp */,
-				C98F29762513FAAE0076E802 /* draw_target.hpp */,
-				C98F29772513FAAE0076E802 /* keyframe_id_base.hpp */,
-				C9601F35251004780032AA07 /* command_path.hpp */,
-				C9601F2C251004770032AA07 /* math */,
-				C9601F36251004780032AA07 /* metrics_path.hpp */,
-				C9601F37251004780032AA07 /* paint */,
-				C9601F47251004780032AA07 /* shapes */,
-				C9601F33251004770032AA07 /* stroke_effect.hpp */,
-				C9601F34251004770032AA07 /* trim_path_base.hpp */,
-				C9601F46251004780032AA07 /* trim_path.hpp */,
-				C9C740AE24FC4F0400EF9516 /* generated */,
-				C9C740E224FC4F0400EF9516 /* backboard.hpp */,
-				C9C740E324FC4F0400EF9516 /* core */,
-				C9C740EC24FC4F0400EF9516 /* status_code.hpp */,
-				C9C740ED24FC4F0400EF9516 /* component_dirt.hpp */,
-				C9C740EE24FC4F0400EF9516 /* renderer.hpp */,
-				C9C740EF24FC4F0400EF9516 /* runtime_header.hpp */,
-				C9C740F024FC4F0400EF9516 /* file.hpp */,
-				C9C740F124FC4F0400EF9516 /* container_component.hpp */,
-				C9C740F224FC4F0400EF9516 /* animation */,
-				C9C740FF24FC4F0500EF9516 /* shapes */,
-				C9C7411E24FC4F0500EF9516 /* math */,
-				C9C7412524FC4F0500EF9516 /* component.hpp */,
-				C9C7412624FC4F0500EF9516 /* node.hpp */,
-				C9C7412724FC4F0500EF9516 /* layout.hpp */,
-				C9C7412824FC4F0500EF9516 /* drawable.hpp */,
-				C9C7412924FC4F0500EF9516 /* artboard.hpp */,
-				C9C7412A24FC4F0500EF9516 /* dependency_sorter.hpp */,
-				C9C7412B24FC4F0500EF9516 /* core_context.hpp */,
-				C9C7412C24FC4F0500EF9516 /* bones */,
-				C9C7413524FC4F0500EF9516 /* core.hpp */,
-				C9C7413624FC4F0500EF9516 /* transform_component.hpp */,
-			);
-			name = include;
-			path = "submodules/rive-cpp/include";
-			sourceTree = "<group>";
-		};
-		C9C740AE24FC4F0400EF9516 /* generated */ = {
-			isa = PBXGroup;
-			children = (
-				04F1C93B26A84BD900CEE6BE /* constraints */,
-				C9C740AF24FC4F0400EF9516 /* core_registry.hpp */,
-				C9C740B024FC4F0400EF9516 /* node_base.hpp */,
-				C9C740B124FC4F0400EF9516 /* transform_component_base.hpp */,
-				C9C740B224FC4F0400EF9516 /* artboard_base.hpp */,
-				C9C740B324FC4F0400EF9516 /* animation */,
-				C9C740BE24FC4F0400EF9516 /* shapes */,
-				C9C740D624FC4F0400EF9516 /* container_component_base.hpp */,
-				C9C740D724FC4F0400EF9516 /* component_base.hpp */,
-				C9C740D824FC4F0400EF9516 /* bones */,
-				C9C740E024FC4F0400EF9516 /* backboard_base.hpp */,
-				C9C740E124FC4F0400EF9516 /* drawable_base.hpp */,
-			);
-			path = generated;
-			sourceTree = "<group>";
-		};
-		C9C740B324FC4F0400EF9516 /* animation */ = {
-			isa = PBXGroup;
-			children = (
-				C9A9DA04265C50C90005DB1F /* blend_animation_1d_base.hpp */,
-				C9A9DA02265C50C90005DB1F /* blend_animation_base.hpp */,
-				C9A9D9FF265C50C90005DB1F /* blend_animation_direct_base.hpp */,
-				C9A9DA03265C50C90005DB1F /* blend_state_1d_base.hpp */,
-				C9A9DA01265C50C90005DB1F /* blend_state_base.hpp */,
-				C9A9DA00265C50C90005DB1F /* blend_state_direct_base.hpp */,
-				C9A9DA05265C50CA0005DB1F /* blend_state_transition_base.hpp */,
-				C9BD38B3263B5DAE00696C37 /* animation_state_base.hpp */,
-				C9BD38A2263B5D9000696C37 /* any_state_base.hpp */,
-				C9BD38A1263B5D9000696C37 /* entry_state_base.hpp */,
-				C9BD38A3263B5D9000696C37 /* exit_state_base.hpp */,
-				C9BD389B263B5D8F00696C37 /* layer_state_base.hpp */,
-				C9BD389A263B5D8F00696C37 /* state_machine_base.hpp */,
-				C9BD38A0263B5D9000696C37 /* state_machine_bool_base.hpp */,
-				C9BD389D263B5D9000696C37 /* state_machine_input_base.hpp */,
-				C9BD389C263B5D9000696C37 /* state_machine_layer_base.hpp */,
-				C9BD38A4263B5D9000696C37 /* state_machine_layer_component_base.hpp */,
-				C9BD389F263B5D9000696C37 /* state_machine_trigger_base.hpp */,
-				C9BD3898263B5D8F00696C37 /* transition_bool_condition_base.hpp */,
-				C9BD3897263B5D8F00696C37 /* transition_condition_base.hpp */,
-				C9BD3899263B5D8F00696C37 /* transition_trigger_condition_base.hpp */,
-				C9BD389E263B5D9000696C37 /* transition_value_condition_base.hpp */,
-				C9BD3892263B5D8200696C37 /* state_machine_component_base.hpp */,
-				C9BD388F263B5D8200696C37 /* state_machine_number_base.hpp */,
-				C9BD3890263B5D8200696C37 /* state_transition_base.hpp */,
-				C9BD3891263B5D8200696C37 /* transition_number_condition_base.hpp */,
-				C9C740B424FC4F0400EF9516 /* keyframe_color_base.hpp */,
-				C9C740B524FC4F0400EF9516 /* keyed_property_base.hpp */,
-				C9C740B624FC4F0400EF9516 /* keyframe_base.hpp */,
-				C9C740B724FC4F0400EF9516 /* animation_base.hpp */,
-				C9C740B824FC4F0400EF9516 /* cubic_interpolator_base.hpp */,
-				C9C740BB24FC4F0400EF9516 /* linear_animation_base.hpp */,
-				C9C740BC24FC4F0400EF9516 /* keyed_object_base.hpp */,
-				C9C740BD24FC4F0400EF9516 /* keyframe_double_base.hpp */,
-			);
-			path = animation;
-			sourceTree = "<group>";
-		};
-		C9C740BE24FC4F0400EF9516 /* shapes */ = {
-			isa = PBXGroup;
-			children = (
-				C9C740BF24FC4F0400EF9516 /* paint */,
-				C9C740C724FC4F0400EF9516 /* parametric_path_base.hpp */,
-				C9C740C824FC4F0400EF9516 /* cubic_asymmetric_vertex_base.hpp */,
-				C9C740C924FC4F0400EF9516 /* cubic_vertex_base.hpp */,
-				C9C740CA24FC4F0400EF9516 /* ellipse_base.hpp */,
-				C9C740CB24FC4F0400EF9516 /* path_composer_base.hpp */,
-				C9C740CC24FC4F0400EF9516 /* points_path_base.hpp */,
-				C9C740CD24FC4F0400EF9516 /* triangle_base.hpp */,
-				C9C740CE24FC4F0400EF9516 /* shape_base.hpp */,
-				C9C740CF24FC4F0400EF9516 /* rectangle_base.hpp */,
-				C9C740D024FC4F0400EF9516 /* cubic_mirrored_vertex_base.hpp */,
-				C9C740D124FC4F0400EF9516 /* straight_vertex_base.hpp */,
-				C9C740D224FC4F0400EF9516 /* path_base.hpp */,
-				C9C740D324FC4F0400EF9516 /* cubic_detached_vertex_base.hpp */,
-				C9C740D424FC4F0400EF9516 /* clipping_shape_base.hpp */,
-				C9C740D524FC4F0400EF9516 /* path_vertex_base.hpp */,
-			);
-			path = shapes;
-			sourceTree = "<group>";
-		};
-		C9C740BF24FC4F0400EF9516 /* paint */ = {
-			isa = PBXGroup;
-			children = (
-				C9C740C024FC4F0400EF9516 /* linear_gradient_base.hpp */,
-				C9C740C124FC4F0400EF9516 /* stroke_base.hpp */,
-				C9C740C224FC4F0400EF9516 /* fill_base.hpp */,
-				C9C740C324FC4F0400EF9516 /* shape_paint_base.hpp */,
-				C9C740C424FC4F0400EF9516 /* solid_color_base.hpp */,
-				C9C740C524FC4F0400EF9516 /* radial_gradient_base.hpp */,
-				C9C740C624FC4F0400EF9516 /* gradient_stop_base.hpp */,
-			);
-			path = paint;
-			sourceTree = "<group>";
-		};
-		C9C740D824FC4F0400EF9516 /* bones */ = {
-			isa = PBXGroup;
-			children = (
-				C9C740D924FC4F0400EF9516 /* weight_base.hpp */,
-				C9C740DA24FC4F0400EF9516 /* root_bone_base.hpp */,
-				C9C740DB24FC4F0400EF9516 /* cubic_weight_base.hpp */,
-				C9C740DC24FC4F0400EF9516 /* bone_base.hpp */,
-				C9C740DD24FC4F0400EF9516 /* skin_base.hpp */,
-				C9C740DE24FC4F0400EF9516 /* tendon_base.hpp */,
-				C9C740DF24FC4F0400EF9516 /* skeletal_component_base.hpp */,
-			);
-			path = bones;
-			sourceTree = "<group>";
-		};
-		C9C740E324FC4F0400EF9516 /* core */ = {
-			isa = PBXGroup;
-			children = (
-				C9C740E424FC4F0400EF9516 /* reader.h */,
-				C9C740E524FC4F0400EF9516 /* field_types */,
-				C9C740EB24FC4F0400EF9516 /* binary_reader.hpp */,
-			);
-			path = core;
-			sourceTree = "<group>";
-		};
-		C9C740E524FC4F0400EF9516 /* field_types */ = {
-			isa = PBXGroup;
-			children = (
-				C9C740E624FC4F0400EF9516 /* core_color_type.hpp */,
-				C9C740E724FC4F0400EF9516 /* core_uint_type.hpp */,
-				C9C740E824FC4F0400EF9516 /* core_double_type.hpp */,
-				C9C740E924FC4F0400EF9516 /* core_string_type.hpp */,
-				C9C740EA24FC4F0400EF9516 /* core_bool_type.hpp */,
-			);
-			path = field_types;
-			sourceTree = "<group>";
-		};
-		C9C740F224FC4F0400EF9516 /* animation */ = {
-			isa = PBXGroup;
-			children = (
-				C9A9D9EE265C50930005DB1F /* animation_state_instance.hpp */,
-				C9A9D9EB265C50930005DB1F /* blend_animation_1d.hpp */,
-				C9A9D9E7265C50930005DB1F /* blend_animation_direct.hpp */,
-				C9A9D9E8265C50930005DB1F /* blend_animation.hpp */,
-				C9A9D9F1265C50930005DB1F /* blend_state_1d_instance.hpp */,
-				C9A9D9EA265C50930005DB1F /* blend_state_1d.hpp */,
-				C9A9D9E5265C50930005DB1F /* blend_state_direct_instance.hpp */,
-				C9A9D9E6265C50930005DB1F /* blend_state_direct.hpp */,
-				C9A9D9E9265C50930005DB1F /* blend_state_instance.hpp */,
-				C9A9D9ED265C50930005DB1F /* blend_state_transition.hpp */,
-				C9A9D9F0265C50930005DB1F /* blend_state.hpp */,
-				C9A9D9EF265C50930005DB1F /* state_instance.hpp */,
-				C9A9D9EC265C50930005DB1F /* system_state_instance.hpp */,
-				C9BD38D3263B5E4000696C37 /* animation_state.hpp */,
-				C9BD38D8263B5E4000696C37 /* any_state.hpp */,
-				C9BD38CE263B5E4000696C37 /* entry_state.hpp */,
-				C9BD38DF263B5E4000696C37 /* exit_state.hpp */,
-				C9BD38E0263B5E4000696C37 /* layer_state.hpp */,
-				C9BD38D2263B5E4000696C37 /* state_machine_bool.hpp */,
-				C9BD38DA263B5E4000696C37 /* state_machine_component.hpp */,
-				C9BD38DD263B5E4000696C37 /* state_machine_input_instance.hpp */,
-				C9BD38D9263B5E4000696C37 /* state_machine_input.hpp */,
-				C9BD38E1263B5E4000696C37 /* state_machine_instance.hpp */,
-				C9BD38CF263B5E4000696C37 /* state_machine_layer_component.hpp */,
-				C9BD38E2263B5E4000696C37 /* state_machine_layer.hpp */,
-				C9BD38D5263B5E4000696C37 /* state_machine_number.hpp */,
-				C9BD38D4263B5E4000696C37 /* state_machine_trigger.hpp */,
-				C9BD38D6263B5E4000696C37 /* state_machine.hpp */,
-				C9BD38CD263B5E4000696C37 /* state_transition_flags.hpp */,
-				C9BD38D7263B5E4000696C37 /* state_transition.hpp */,
-				C9BD38D1263B5E4000696C37 /* transition_bool_condition.hpp */,
-				C9BD38DB263B5E4000696C37 /* transition_condition_op.hpp */,
-				C9BD38CC263B5E4000696C37 /* transition_condition.hpp */,
-				C9BD38DE263B5E4000696C37 /* transition_number_condition.hpp */,
-				C9BD38DC263B5E4000696C37 /* transition_trigger_condition.hpp */,
-				C9BD38D0263B5E4000696C37 /* transition_value_condition.hpp */,
-				C98F296E2513FA8B0076E802 /* keyframe_id.hpp */,
-				C9C740F324FC4F0500EF9516 /* cubic_interpolator.hpp */,
-				C9C740F424FC4F0500EF9516 /* keyed_property.hpp */,
-				C9C740F724FC4F0500EF9516 /* animation.hpp */,
-				C9C740F824FC4F0500EF9516 /* keyframe.hpp */,
-				C9C740F924FC4F0500EF9516 /* keyed_object.hpp */,
-				C9C740FA24FC4F0500EF9516 /* linear_animation.hpp */,
-				C9C740FB24FC4F0500EF9516 /* linear_animation_instance.hpp */,
-				C9C740FC24FC4F0500EF9516 /* keyframe_double.hpp */,
-				C9C740FD24FC4F0500EF9516 /* loop.hpp */,
-				C9C740FE24FC4F0500EF9516 /* keyframe_color.hpp */,
-			);
-			path = animation;
-			sourceTree = "<group>";
-		};
-		C9C740FF24FC4F0500EF9516 /* shapes */ = {
-			isa = PBXGroup;
-			children = (
-				C9C7410024FC4F0500EF9516 /* straight_vertex.hpp */,
-				C9C7410124FC4F0500EF9516 /* paint */,
-				C9C7410E24FC4F0500EF9516 /* path_composer.hpp */,
-				C9C7410F24FC4F0500EF9516 /* shape_paint_container.hpp */,
-				C9C7411024FC4F0500EF9516 /* cubic_mirrored_vertex.hpp */,
-				C9C7411124FC4F0500EF9516 /* path_space.hpp */,
-				C9C7411224FC4F0500EF9516 /* ellipse.hpp */,
-				C9C7411324FC4F0500EF9516 /* clipping_shape.hpp */,
-				C9C7411424FC4F0500EF9516 /* cubic_vertex.hpp */,
-				C9C7411524FC4F0500EF9516 /* shape.hpp */,
-				C9C7411624FC4F0500EF9516 /* triangle.hpp */,
-				C9C7411724FC4F0500EF9516 /* path.hpp */,
-				C9C7411824FC4F0500EF9516 /* path_vertex.hpp */,
-				C9C7411924FC4F0500EF9516 /* parametric_path.hpp */,
-				C9C7411A24FC4F0500EF9516 /* rectangle.hpp */,
-				C9C7411B24FC4F0500EF9516 /* points_path.hpp */,
-				C9C7411C24FC4F0500EF9516 /* cubic_asymmetric_vertex.hpp */,
-				C9C7411D24FC4F0500EF9516 /* cubic_detached_vertex.hpp */,
-			);
-			path = shapes;
-			sourceTree = "<group>";
-		};
-		C9C7410124FC4F0500EF9516 /* paint */ = {
-			isa = PBXGroup;
-			children = (
-				C9C7410224FC4F0500EF9516 /* stroke_cap.hpp */,
-				C9C7410324FC4F0500EF9516 /* gradient_stop.hpp */,
-				C9C7410424FC4F0500EF9516 /* stroke.hpp */,
-				C9C7410524FC4F0500EF9516 /* shape_paint_mutator.hpp */,
-				C9C7410624FC4F0500EF9516 /* blend_mode.hpp */,
-				C9C7410724FC4F0500EF9516 /* shape_paint.hpp */,
-				C9C7410824FC4F0500EF9516 /* stroke_join.hpp */,
-				C9C7410924FC4F0500EF9516 /* fill.hpp */,
-				C9C7410A24FC4F0500EF9516 /* radial_gradient.hpp */,
-				C9C7410B24FC4F0500EF9516 /* color.hpp */,
-				C9C7410C24FC4F0500EF9516 /* solid_color.hpp */,
-				C9C7410D24FC4F0500EF9516 /* linear_gradient.hpp */,
-			);
-			path = paint;
-			sourceTree = "<group>";
-		};
-		C9C7411E24FC4F0500EF9516 /* math */ = {
-			isa = PBXGroup;
-			children = (
-				C9C7411F24FC4F0500EF9516 /* vec2d.hpp */,
-				C9C7412024FC4F0500EF9516 /* mat2d.hpp */,
-				C9C7412124FC4F0500EF9516 /* aabb.hpp */,
-				C9C7412224FC4F0500EF9516 /* color.hpp */,
-				C9C7412324FC4F0500EF9516 /* transform_components.hpp */,
-				C9C7412424FC4F0500EF9516 /* circle_constant.hpp */,
-			);
-			path = math;
-			sourceTree = "<group>";
-		};
-		C9C7412C24FC4F0500EF9516 /* bones */ = {
-			isa = PBXGroup;
-			children = (
-				C9C7412D24FC4F0500EF9516 /* tendon.hpp */,
-				C9C7412E24FC4F0500EF9516 /* skeletal_component.hpp */,
-				C9C7412F24FC4F0500EF9516 /* weight.hpp */,
-				C9C7413024FC4F0500EF9516 /* skin.hpp */,
-				C9C7413124FC4F0500EF9516 /* root_bone.hpp */,
-				C9C7413224FC4F0500EF9516 /* bone.hpp */,
-				C9C7413324FC4F0500EF9516 /* skinnable.hpp */,
-				C9C7413424FC4F0500EF9516 /* cubic_weight.hpp */,
-			);
-			path = bones;
-			sourceTree = "<group>";
-		};
 		C9D60DA62512AFE900AAA3A6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -1850,241 +1718,247 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		04F4628E26C405A6007CEEAB /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C9C73ECC24FC478800EF9516 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				04F4627126C4030D007CEEAB /* points_path.hpp in Headers */,
+				04F461DD26C4030D007CEEAB /* blend_state_1d_base.hpp in Headers */,
+				04F4622226C4030D007CEEAB /* container_component.hpp in Headers */,
+				04F4626226C4030D007CEEAB /* path_composer.hpp in Headers */,
+				04F4623E26C4030D007CEEAB /* transition_condition.hpp in Headers */,
 				046FB7F7264EAA60000129B1 /* RiveFile.h in Headers */,
+				04F4622326C4030D007CEEAB /* transition_bool_condition.hpp in Headers */,
 				046FB7FC264EAA61000129B1 /* RiveArtboard.h in Headers */,
-				0450446B26B3F7C1007B25CA /* transform_space.hpp in Headers */,
-				C9A9DA09265C50CA0005DB1F /* blend_animation_base.hpp in Headers */,
+				04F461BA26C4030D007CEEAB /* transform_constraint_base.hpp in Headers */,
+				04F461EC26C4030D007CEEAB /* ellipse_base.hpp in Headers */,
+				04F461C726C4030D007CEEAB /* linear_animation_base.hpp in Headers */,
+				04F461F526C4030D007CEEAB /* polygon_base.hpp in Headers */,
 				046FB7FD264EAA61000129B1 /* RiveLinearAnimation.h in Headers */,
-				C9A9D9FC265C50930005DB1F /* state_instance.hpp in Headers */,
+				04F461E626C4030D007CEEAB /* trim_path_base.hpp in Headers */,
+				04F4627A26C4030D007CEEAB /* circle_constant.hpp in Headers */,
+				04F4620F26C4030D007CEEAB /* constraint.hpp in Headers */,
+				04F461F426C4030D007CEEAB /* path_base.hpp in Headers */,
+				04F4625126C4030D007CEEAB /* transition_trigger_condition.hpp in Headers */,
+				04F4627526C4030D007CEEAB /* vec2d.hpp in Headers */,
+				04F461F126C4030D007CEEAB /* cubic_mirrored_vertex_base.hpp in Headers */,
+				04F461EA26C4030D007CEEAB /* cubic_asymmetric_vertex_base.hpp in Headers */,
+				04F4627026C4030D007CEEAB /* rectangle.hpp in Headers */,
+				04F4624D26C4030D007CEEAB /* exit_state.hpp in Headers */,
+				04F4624F26C4030D007CEEAB /* animation_state.hpp in Headers */,
+				04F4626126C4030D007CEEAB /* stroke_effect.hpp in Headers */,
+				04F461EE26C4030D007CEEAB /* triangle_base.hpp in Headers */,
+				04F4621B26C4030D007CEEAB /* import_stack.hpp in Headers */,
+				04F4622A26C4030D007CEEAB /* state_machine_trigger.hpp in Headers */,
+				04F461F726C4030D007CEEAB /* clipping_shape_base.hpp in Headers */,
+				04F461CF26C4030D007CEEAB /* keyed_object_base.hpp in Headers */,
+				04F461FB26C4030D007CEEAB /* weight_base.hpp in Headers */,
+				04F4620026C4030D007CEEAB /* tendon_base.hpp in Headers */,
+				04F4626026C4030D007CEEAB /* linear_gradient.hpp in Headers */,
+				04F4620D26C4030D007CEEAB /* status_code.hpp in Headers */,
+				04F4622526C4030D007CEEAB /* keyed_property.hpp in Headers */,
+				04F4627426C4030D007CEEAB /* cubic_detached_vertex.hpp in Headers */,
+				04F4620726C4030D007CEEAB /* core_color_type.hpp in Headers */,
+				04F461D726C4030D007CEEAB /* transition_bool_condition_base.hpp in Headers */,
+				04F4623226C4030D007CEEAB /* state_machine_layer.hpp in Headers */,
+				04F4628C26C4030D007CEEAB /* core.hpp in Headers */,
+				04F4621226C4030D007CEEAB /* distance_constraint.hpp in Headers */,
+				04F4620626C4030D007CEEAB /* reader.h in Headers */,
+				04F4625B26C4030D007CEEAB /* fill.hpp in Headers */,
+				04F4626F26C4030D007CEEAB /* parametric_path.hpp in Headers */,
+				04F461E326C4030D007CEEAB /* fill_base.hpp in Headers */,
+				04F4622926C4030D007CEEAB /* system_state_instance.hpp in Headers */,
+				04F4625026C4030D007CEEAB /* blend_state_direct.hpp in Headers */,
+				04F4628D26C4030D007CEEAB /* transform_component.hpp in Headers */,
+				04F461B626C4030D007CEEAB /* transform_component_base.hpp in Headers */,
 				046FB800264EAA61000129B1 /* RiveStateMachineInstance.h in Headers */,
+				04F461EF26C4030D007CEEAB /* shape_base.hpp in Headers */,
+				04F4623426C4030D007CEEAB /* state_machine_layer_component.hpp in Headers */,
+				04F461D826C4030D007CEEAB /* transition_trigger_condition_base.hpp in Headers */,
+				04F4624826C4030D007CEEAB /* keyframe_color.hpp in Headers */,
+				04F461ED26C4030D007CEEAB /* points_path_base.hpp in Headers */,
 				046FB7FB264EAA61000129B1 /* RiveSMIInput.h in Headers */,
+				04F4622726C4030D007CEEAB /* layer_state.hpp in Headers */,
+				04F4624926C4030D007CEEAB /* entry_state.hpp in Headers */,
+				04F4623526C4030D007CEEAB /* blend_state_instance.hpp in Headers */,
+				04F4623B26C4030D007CEEAB /* state_machine.hpp in Headers */,
+				04F4624026C4030D007CEEAB /* animation_state_instance.hpp in Headers */,
+				04F4620C26C4030D007CEEAB /* binary_reader.hpp in Headers */,
+				04F4626826C4030D007CEEAB /* metrics_path.hpp in Headers */,
+				04F4622426C4030D007CEEAB /* cubic_interpolator.hpp in Headers */,
+				04F461D426C4030D007CEEAB /* state_machine_bool_base.hpp in Headers */,
+				04F4621726C4030D007CEEAB /* state_machine_layer_importer.hpp in Headers */,
+				04F4625426C4030D007CEEAB /* stroke_cap.hpp in Headers */,
+				04F461C126C4030D007CEEAB /* keyframe_base.hpp in Headers */,
+				04F461B926C4030D007CEEAB /* ik_constraint_base.hpp in Headers */,
+				04F4623326C4030D007CEEAB /* blend_animation_1d.hpp in Headers */,
+				04F4623626C4030D007CEEAB /* state_machine_bool.hpp in Headers */,
+				04F461CC26C4030D007CEEAB /* state_machine_layer_base.hpp in Headers */,
+				04F4625E26C4030D007CEEAB /* color.hpp in Headers */,
+				04F461C226C4030D007CEEAB /* animation_state_base.hpp in Headers */,
+				04F461D026C4030D007CEEAB /* transition_value_condition_base.hpp in Headers */,
 				046FB7FE264EAA61000129B1 /* RiveStateMachine.h in Headers */,
-				04F1C93F26A84BD900CEE6BE /* constraint_base.hpp in Headers */,
+				04F461BF26C4030D007CEEAB /* keyframe_color_base.hpp in Headers */,
 				046FB7F3264EAA60000129B1 /* RiveStateMachineInput.h in Headers */,
+				04F4620526C4030D007CEEAB /* backboard.hpp in Headers */,
+				04F4621C26C4030D007CEEAB /* layer_state_importer.hpp in Headers */,
+				04F4623926C4030D007CEEAB /* keyed_object.hpp in Headers */,
+				04F4626926C4030D007CEEAB /* cubic_vertex.hpp in Headers */,
+				04F4625C26C4030D007CEEAB /* radial_gradient.hpp in Headers */,
+				04F4626426C4030D007CEEAB /* cubic_mirrored_vertex.hpp in Headers */,
+				04F4625A26C4030D007CEEAB /* stroke_join.hpp in Headers */,
+				04F4620826C4030D007CEEAB /* core_uint_type.hpp in Headers */,
+				04F4627326C4030D007CEEAB /* cubic_asymmetric_vertex.hpp in Headers */,
+				04F4627726C4030D007CEEAB /* aabb.hpp in Headers */,
+				04F461B726C4030D007CEEAB /* constraint_base.hpp in Headers */,
+				04F4621026C4030D007CEEAB /* ik_constraint.hpp in Headers */,
+				04F4620326C4030D007CEEAB /* backboard_base.hpp in Headers */,
+				04F4624A26C4030D007CEEAB /* blend_animation.hpp in Headers */,
+				04F4626E26C4030D007CEEAB /* path_vertex.hpp in Headers */,
+				04F4620926C4030D007CEEAB /* core_double_type.hpp in Headers */,
+				04F4622E26C4030D007CEEAB /* state_machine_number.hpp in Headers */,
+				04F4628026C4030D007CEEAB /* artboard.hpp in Headers */,
+				04F4628A26C4030D007CEEAB /* cubic_weight.hpp in Headers */,
+				04F4628926C4030D007CEEAB /* skinnable.hpp in Headers */,
+				04F4623826C4030D007CEEAB /* state_instance.hpp in Headers */,
+				04F461E926C4030D007CEEAB /* parametric_path_base.hpp in Headers */,
+				04F461C926C4030D007CEEAB /* layer_state_base.hpp in Headers */,
+				04F4621626C4030D007CEEAB /* state_transition_importer.hpp in Headers */,
+				04F4628126C4030D007CEEAB /* dependency_sorter.hpp in Headers */,
+				04F4625626C4030D007CEEAB /* stroke.hpp in Headers */,
+				04F461C626C4030D007CEEAB /* cubic_interpolator_base.hpp in Headers */,
+				04F461CA26C4030D007CEEAB /* state_machine_layer_component_base.hpp in Headers */,
+				04F4623126C4030D007CEEAB /* blend_state.hpp in Headers */,
+				04F461C326C4030D007CEEAB /* animation_base.hpp in Headers */,
+				04F461F626C4030D007CEEAB /* cubic_detached_vertex_base.hpp in Headers */,
+				04F4625726C4030D007CEEAB /* shape_paint_mutator.hpp in Headers */,
+				04F4628726C4030D007CEEAB /* root_bone.hpp in Headers */,
+				04F461B526C4030D007CEEAB /* node_base.hpp in Headers */,
+				04F461FC26C4030D007CEEAB /* root_bone_base.hpp in Headers */,
+				04F461BE26C4030D007CEEAB /* blend_animation_base.hpp in Headers */,
+				04F4624B26C4030D007CEEAB /* state_machine_instance.hpp in Headers */,
+				04F461D126C4030D007CEEAB /* state_machine_number_base.hpp in Headers */,
+				04F461D526C4030D007CEEAB /* blend_state_transition_base.hpp in Headers */,
+				04F461E426C4030D007CEEAB /* shape_paint_base.hpp in Headers */,
+				04F4625226C4030D007CEEAB /* transform_space.hpp in Headers */,
+				04F461C826C4030D007CEEAB /* entry_state_base.hpp in Headers */,
+				04F461E726C4030D007CEEAB /* radial_gradient_base.hpp in Headers */,
+				04F4627D26C4030D007CEEAB /* node.hpp in Headers */,
+				04F4628426C4030D007CEEAB /* skeletal_component.hpp in Headers */,
+				04F4627E26C4030D007CEEAB /* layout.hpp in Headers */,
+				04F461CB26C4030D007CEEAB /* blend_state_direct_base.hpp in Headers */,
+				04F4624326C4030D007CEEAB /* transition_condition_op.hpp in Headers */,
+				04F4621F26C4030D007CEEAB /* draw_target.hpp in Headers */,
+				04F4628826C4030D007CEEAB /* bone.hpp in Headers */,
+				04F4621E26C4030D007CEEAB /* state_machine_importer.hpp in Headers */,
+				04F4622F26C4030D007CEEAB /* animation.hpp in Headers */,
+				04F4626526C4030D007CEEAB /* path_space.hpp in Headers */,
+				04F4628226C4030D007CEEAB /* core_context.hpp in Headers */,
+				04F4627926C4030D007CEEAB /* transform_components.hpp in Headers */,
+				04F4624726C4030D007CEEAB /* loop.hpp in Headers */,
+				04F4624626C4030D007CEEAB /* blend_animation_direct.hpp in Headers */,
+				04F461B826C4030D007CEEAB /* targeted_constraint_base.hpp in Headers */,
+				04F461FF26C4030D007CEEAB /* skin_base.hpp in Headers */,
+				04F4628626C4030D007CEEAB /* skin.hpp in Headers */,
+				04F4625526C4030D007CEEAB /* gradient_stop.hpp in Headers */,
+				04F461F226C4030D007CEEAB /* star_base.hpp in Headers */,
+				04F461D226C4030D007CEEAB /* state_transition_base.hpp in Headers */,
+				04F4622C26C4030D007CEEAB /* blend_state_transition.hpp in Headers */,
+				04F4620A26C4030D007CEEAB /* core_string_type.hpp in Headers */,
+				04F4624226C4030D007CEEAB /* linear_animation_instance.hpp in Headers */,
+				04F461E026C4030D007CEEAB /* exit_state_base.hpp in Headers */,
+				04F4620426C4030D007CEEAB /* drawable_base.hpp in Headers */,
+				04F4628B26C4030D007CEEAB /* draw_rules.hpp in Headers */,
+				04F4626626C4030D007CEEAB /* ellipse.hpp in Headers */,
+				04F4622126C4030D007CEEAB /* file.hpp in Headers */,
+				04F4621826C4030D007CEEAB /* keyed_property_importer.hpp in Headers */,
+				04F461F026C4030D007CEEAB /* rectangle_base.hpp in Headers */,
+				04F461BC26C4030D007CEEAB /* artboard_base.hpp in Headers */,
+				04F4628526C4030D007CEEAB /* weight.hpp in Headers */,
+				04F4627626C4030D007CEEAB /* mat2d.hpp in Headers */,
+				04F461DF26C4030D007CEEAB /* state_machine_base.hpp in Headers */,
+				04F4622626C4030D007CEEAB /* state_machine_input.hpp in Headers */,
+				04F461FD26C4030D007CEEAB /* cubic_weight_base.hpp in Headers */,
+				04F461E526C4030D007CEEAB /* solid_color_base.hpp in Headers */,
+				04F4625826C4030D007CEEAB /* blend_mode.hpp in Headers */,
+				04F4621326C4030D007CEEAB /* component_dirt.hpp in Headers */,
 				046FB7F1264EAA60000129B1 /* RiveLinearAnimationInstance.h in Headers */,
+				04F4621526C4030D007CEEAB /* draw_target_placement.hpp in Headers */,
+				04F4626C26C4030D007CEEAB /* path.hpp in Headers */,
+				04F461C026C4030D007CEEAB /* keyed_property_base.hpp in Headers */,
+				04F461CD26C4030D007CEEAB /* keyframe_id_base.hpp in Headers */,
+				04F461E126C4030D007CEEAB /* linear_gradient_base.hpp in Headers */,
+				04F461C526C4030D007CEEAB /* transition_number_condition_base.hpp in Headers */,
+				04F4626B26C4030D007CEEAB /* triangle.hpp in Headers */,
+				04F4621426C4030D007CEEAB /* renderer.hpp in Headers */,
+				04F4620B26C4030D007CEEAB /* core_bool_type.hpp in Headers */,
+				04F4620E26C4030D007CEEAB /* targeted_constraint.hpp in Headers */,
+				04F461DB26C4030D007CEEAB /* transition_condition_base.hpp in Headers */,
+				04F4626726C4030D007CEEAB /* clipping_shape.hpp in Headers */,
+				04F461F926C4030D007CEEAB /* container_component_base.hpp in Headers */,
+				04F4625326C4030D007CEEAB /* straight_vertex.hpp in Headers */,
+				04F4626326C4030D007CEEAB /* shape_paint_container.hpp in Headers */,
+				04F461B426C4030D007CEEAB /* core_registry.hpp in Headers */,
+				04F461C426C4030D007CEEAB /* blend_state_base.hpp in Headers */,
+				04F461EB26C4030D007CEEAB /* cubic_vertex_base.hpp in Headers */,
+				04F4623726C4030D007CEEAB /* blend_state_1d.hpp in Headers */,
+				04F4624C26C4030D007CEEAB /* state_transition_flags.hpp in Headers */,
+				04F4620126C4030D007CEEAB /* skeletal_component_base.hpp in Headers */,
+				04F4624426C4030D007CEEAB /* blend_state_direct_instance.hpp in Headers */,
+				04F4623026C4030D007CEEAB /* keyframe.hpp in Headers */,
+				04F461F826C4030D007CEEAB /* path_vertex_base.hpp in Headers */,
+				04F4621D26C4030D007CEEAB /* artboard_importer.hpp in Headers */,
+				04F4623A26C4030D007CEEAB /* state_machine_component.hpp in Headers */,
 				04BE5430264D1F4100427B39 /* LayerState.h in Headers */,
-				C9A9D9F3265C50930005DB1F /* blend_state_direct.hpp in Headers */,
-				C9BD38F5263B5E4000696C37 /* transition_number_condition.hpp in Headers */,
-				C9C741D624FC4F0500EF9516 /* mat2d.hpp in Headers */,
-				C9A9DA0C265C50CA0005DB1F /* blend_state_transition_base.hpp in Headers */,
-				C9C741D724FC4F0500EF9516 /* aabb.hpp in Headers */,
-				C9A9D9FD265C50930005DB1F /* blend_state.hpp in Headers */,
-				C9A9DA06265C50CA0005DB1F /* blend_animation_direct_base.hpp in Headers */,
-				C9C741DA24FC4F0500EF9516 /* circle_constant.hpp in Headers */,
-				C9601F97251004780032AA07 /* metrics_path.hpp in Headers */,
-				C9C741CC24FC4F0500EF9516 /* shape.hpp in Headers */,
-				C9C741CF24FC4F0500EF9516 /* path_vertex.hpp in Headers */,
-				C9C741D124FC4F0500EF9516 /* rectangle.hpp in Headers */,
-				C9C741D224FC4F0500EF9516 /* points_path.hpp in Headers */,
-				C9C741D424FC4F0500EF9516 /* cubic_detached_vertex.hpp in Headers */,
-				C9601F80251004780032AA07 /* stroke_effect.hpp in Headers */,
-				C9601F7C251004780032AA07 /* trim_path.hpp in Headers */,
-				04C8D517265BFE3500508ACB /* runtime_header.hpp in Headers */,
-				C9A9D9F7265C50930005DB1F /* blend_state_1d.hpp in Headers */,
-				C9601F82251004780032AA07 /* straight_vertex.hpp in Headers */,
-				04F1C93A26A84BB400CEE6BE /* ik_constraint.hpp in Headers */,
-				C9601F73251004780032AA07 /* stroke_cap.hpp in Headers */,
-				C9601F84251004780032AA07 /* gradient_stop.hpp in Headers */,
-				C9601F75251004780032AA07 /* stroke.hpp in Headers */,
-				C9601F86251004780032AA07 /* shape_paint_mutator.hpp in Headers */,
-				C9601F87251004780032AA07 /* blend_mode.hpp in Headers */,
-				C9601F88251004780032AA07 /* shape_paint.hpp in Headers */,
-				0450446826B3F7A5007B25CA /* distance_constraint_base.hpp in Headers */,
-				C9601F79251004780032AA07 /* stroke_join.hpp in Headers */,
-				C9601F7A251004780032AA07 /* fill.hpp in Headers */,
-				C9601F8B251004780032AA07 /* radial_gradient.hpp in Headers */,
-				C9601F8D251004780032AA07 /* color.hpp in Headers */,
-				C9601F8E251004780032AA07 /* solid_color.hpp in Headers */,
-				C9601F7F251004780032AA07 /* linear_gradient.hpp in Headers */,
-				C9601F91251004780032AA07 /* path_composer.hpp in Headers */,
-				C9601F92251004780032AA07 /* shape_paint_container.hpp in Headers */,
-				C9601F93251004780032AA07 /* cubic_mirrored_vertex.hpp in Headers */,
-				C9601F94251004780032AA07 /* path_space.hpp in Headers */,
-				C9601F95251004780032AA07 /* ellipse.hpp in Headers */,
-				C9601F96251004780032AA07 /* clipping_shape.hpp in Headers */,
-				C9601F98251004780032AA07 /* cubic_vertex.hpp in Headers */,
-				C9601F9A251004780032AA07 /* triangle.hpp in Headers */,
-				C9601F9B251004780032AA07 /* path.hpp in Headers */,
-				C9601F9D251004780032AA07 /* parametric_path.hpp in Headers */,
-				C9601FA0251004780032AA07 /* cubic_asymmetric_vertex.hpp in Headers */,
-				C9601F69251004780032AA07 /* vec2d.hpp in Headers */,
-				C9601F6C251004780032AA07 /* color.hpp in Headers */,
-				C9601F6D251004780032AA07 /* transform_components.hpp in Headers */,
-				C9BD38ED263B5E4000696C37 /* state_machine.hpp in Headers */,
 				C9C741F424FC510200EF9516 /* Rive.h in Headers */,
-				C9BD38B2263B5D9000696C37 /* state_machine_layer_component_base.hpp in Headers */,
-				C9C741DF24FC4F0500EF9516 /* artboard.hpp in Headers */,
+				04F4625926C4030D007CEEAB /* shape_paint.hpp in Headers */,
+				04F4624126C4030D007CEEAB /* linear_animation.hpp in Headers */,
+				04F4623D26C4030D007CEEAB /* state_machine_input_instance.hpp in Headers */,
+				04F461D926C4030D007CEEAB /* state_machine_component_base.hpp in Headers */,
+				04F4621926C4030D007CEEAB /* keyed_object_importer.hpp in Headers */,
+				04F4620226C4030D007CEEAB /* draw_target_base.hpp in Headers */,
+				04F4623F26C4030D007CEEAB /* transition_value_condition.hpp in Headers */,
+				04F4627B26C4030D007CEEAB /* command_path.hpp in Headers */,
+				04F4627C26C4030D007CEEAB /* component.hpp in Headers */,
+				04F461FE26C4030D007CEEAB /* bone_base.hpp in Headers */,
+				04F4622B26C4030D007CEEAB /* keyframe_id.hpp in Headers */,
+				04F4623C26C4030D007CEEAB /* blend_state_1d_instance.hpp in Headers */,
+				04F461F326C4030D007CEEAB /* straight_vertex_base.hpp in Headers */,
 				04BE5436264D2A7500427B39 /* RivePrivateHeaders.h in Headers */,
-				C9C741B324FC4F0500EF9516 /* linear_animation.hpp in Headers */,
-				C9BD38CB263B5E0D00696C37 /* state_machine_importer.hpp in Headers */,
-				C9C741E524FC4F0500EF9516 /* skin.hpp in Headers */,
-				C9BD3894263B5D8300696C37 /* state_transition_base.hpp in Headers */,
-				0450446426B3F74A007B25CA /* transform_constraint.hpp in Headers */,
-				C9BD38EA263B5E4000696C37 /* animation_state.hpp in Headers */,
-				C9BD38AE263B5D9000696C37 /* state_machine_bool_base.hpp in Headers */,
-				C9BD38C8263B5E0D00696C37 /* import_stack.hpp in Headers */,
-				C9BD38AB263B5D9000696C37 /* state_machine_input_base.hpp in Headers */,
-				C9C7418624FC4F0500EF9516 /* cubic_vertex_base.hpp in Headers */,
-				C98F296F2513FA8B0076E802 /* keyframe_id.hpp in Headers */,
-				C9C741B624FC4F0500EF9516 /* loop.hpp in Headers */,
-				C9A9D9F2265C50930005DB1F /* blend_state_direct_instance.hpp in Headers */,
-				C9BD3893263B5D8300696C37 /* state_machine_number_base.hpp in Headers */,
-				C9601F71251004780032AA07 /* command_path.hpp in Headers */,
-				C9BD38F1263B5E4000696C37 /* state_machine_component.hpp in Headers */,
-				04F1C93826A84BB400CEE6BE /* targeted_constraint.hpp in Headers */,
-				C9BD38C3263B5E0D00696C37 /* state_transition_importer.hpp in Headers */,
-				C9C7419A24FC4F0500EF9516 /* tendon_base.hpp in Headers */,
-				C9BD38AC263B5D9000696C37 /* transition_value_condition_base.hpp in Headers */,
-				C9BD38AF263B5D9000696C37 /* entry_state_base.hpp in Headers */,
-				C9C741EA24FC4F0500EF9516 /* core.hpp in Headers */,
-				C9BD38A7263B5D9000696C37 /* transition_trigger_condition_base.hpp in Headers */,
-				C9A9D9FE265C50930005DB1F /* blend_state_1d_instance.hpp in Headers */,
-				04F1C94126A84BD900CEE6BE /* ik_constraint_base.hpp in Headers */,
-				C9A9DA07265C50CA0005DB1F /* blend_state_direct_base.hpp in Headers */,
-				C9C741A624FC4F0500EF9516 /* status_code.hpp in Headers */,
-				C9BD38E3263B5E4000696C37 /* transition_condition.hpp in Headers */,
-				C9C741A024FC4F0500EF9516 /* core_color_type.hpp in Headers */,
-				C9BD38F6263B5E4000696C37 /* exit_state.hpp in Headers */,
-				C9BD38E7263B5E4000696C37 /* transition_value_condition.hpp in Headers */,
-				C9C7418924FC4F0500EF9516 /* points_path_base.hpp in Headers */,
-				C9C7419F24FC4F0500EF9516 /* reader.h in Headers */,
-				C98F297D2513FAAE0076E802 /* keyframe_id_base.hpp in Headers */,
-				C9BD38A9263B5D9000696C37 /* layer_state_base.hpp in Headers */,
-				C9A9D9F5265C50930005DB1F /* blend_animation.hpp in Headers */,
-				C9C7419424FC4F0500EF9516 /* component_base.hpp in Headers */,
-				C9BD38B0263B5D9000696C37 /* any_state_base.hpp in Headers */,
-				04F1C93926A84BB400CEE6BE /* constraint.hpp in Headers */,
-				C9C741A324FC4F0500EF9516 /* core_string_type.hpp in Headers */,
-				C9C7417D24FC4F0500EF9516 /* linear_gradient_base.hpp in Headers */,
-				C9C7418424FC4F0500EF9516 /* parametric_path_base.hpp in Headers */,
-				C9AEB7E825C8903C00AE9C43 /* star_base.hpp in Headers */,
-				C9BD38F2263B5E4000696C37 /* transition_condition_op.hpp in Headers */,
-				C9C7419B24FC4F0500EF9516 /* skeletal_component_base.hpp in Headers */,
-				C9BD38AA263B5D9000696C37 /* state_machine_layer_base.hpp in Headers */,
-				C9BD38EC263B5E4000696C37 /* state_machine_number.hpp in Headers */,
-				C9C7416F24FC4F0500EF9516 /* core_registry.hpp in Headers */,
-				C9BD38B4263B5DAE00696C37 /* animation_state_base.hpp in Headers */,
-				C9C741AA24FC4F0500EF9516 /* file.hpp in Headers */,
-				C9A9D9F6265C50930005DB1F /* blend_state_instance.hpp in Headers */,
-				C9C7419924FC4F0500EF9516 /* skin_base.hpp in Headers */,
-				C9C7418224FC4F0500EF9516 /* radial_gradient_base.hpp in Headers */,
-				C98F297B2513FAAE0076E802 /* draw_target_placement.hpp in Headers */,
-				C9C7417724FC4F0500EF9516 /* cubic_interpolator_base.hpp in Headers */,
-				C9C7419724FC4F0500EF9516 /* cubic_weight_base.hpp in Headers */,
-				C98F297A2513FAAE0076E802 /* draw_rules_base.hpp in Headers */,
-				C9C741B024FC4F0500EF9516 /* animation.hpp in Headers */,
-				C9BD38AD263B5D9000696C37 /* state_machine_trigger_base.hpp in Headers */,
-				C9C741B424FC4F0500EF9516 /* linear_animation_instance.hpp in Headers */,
-				C9C7419624FC4F0500EF9516 /* root_bone_base.hpp in Headers */,
-				C9C741E224FC4F0500EF9516 /* tendon.hpp in Headers */,
-				C9C741E724FC4F0500EF9516 /* bone.hpp in Headers */,
-				C9601F70251004780032AA07 /* trim_path_base.hpp in Headers */,
-				C9C7417024FC4F0500EF9516 /* node_base.hpp in Headers */,
-				C9C7418A24FC4F0500EF9516 /* triangle_base.hpp in Headers */,
-				C9C7418324FC4F0500EF9516 /* gradient_stop_base.hpp in Headers */,
-				C9BD38B7263B5DD400696C37 /* polygon.hpp in Headers */,
-				C9C7418824FC4F0500EF9516 /* path_composer_base.hpp in Headers */,
-				C9C7417224FC4F0500EF9516 /* artboard_base.hpp in Headers */,
-				C9C741B224FC4F0500EF9516 /* keyed_object.hpp in Headers */,
-				C9BD38E5263B5E4000696C37 /* entry_state.hpp in Headers */,
-				C9C741DC24FC4F0500EF9516 /* node.hpp in Headers */,
-				C9C7418F24FC4F0500EF9516 /* path_base.hpp in Headers */,
-				C9A9DA0A265C50CA0005DB1F /* blend_state_1d_base.hpp in Headers */,
-				C9A9D9F8265C50930005DB1F /* blend_animation_1d.hpp in Headers */,
-				C9BD38CA263B5E0D00696C37 /* artboard_importer.hpp in Headers */,
-				0450446526B3F74A007B25CA /* distance_constraint.hpp in Headers */,
-				C9C7419324FC4F0500EF9516 /* container_component_base.hpp in Headers */,
-				C9C7419524FC4F0500EF9516 /* weight_base.hpp in Headers */,
-				C9BD38A6263B5D9000696C37 /* transition_bool_condition_base.hpp in Headers */,
-				C9BD38F9263B5E4000696C37 /* state_machine_layer.hpp in Headers */,
-				C9C741E824FC4F0500EF9516 /* skinnable.hpp in Headers */,
-				C9BD38F0263B5E4000696C37 /* state_machine_input.hpp in Headers */,
-				C9C7418524FC4F0500EF9516 /* cubic_asymmetric_vertex_base.hpp in Headers */,
-				C9C741E624FC4F0500EF9516 /* root_bone.hpp in Headers */,
-				C98F297C2513FAAE0076E802 /* draw_target.hpp in Headers */,
-				C9C7419E24FC4F0500EF9516 /* backboard.hpp in Headers */,
-				C9BD3896263B5D8300696C37 /* state_machine_component_base.hpp in Headers */,
-				C9BD38E6263B5E4000696C37 /* state_machine_layer_component.hpp in Headers */,
-				C9C741DD24FC4F0500EF9516 /* layout.hpp in Headers */,
-				C9BD38A5263B5D9000696C37 /* transition_condition_base.hpp in Headers */,
-				C9C741A724FC4F0500EF9516 /* component_dirt.hpp in Headers */,
-				C9C741E124FC4F0500EF9516 /* core_context.hpp in Headers */,
-				C9C741AC24FC4F0500EF9516 /* cubic_interpolator.hpp in Headers */,
-				C9C741A824FC4F0500EF9516 /* renderer.hpp in Headers */,
-				C9BD38EE263B5E4000696C37 /* state_transition.hpp in Headers */,
-				C9C7418724FC4F0500EF9516 /* ellipse_base.hpp in Headers */,
-				C9C7418E24FC4F0500EF9516 /* straight_vertex_base.hpp in Headers */,
-				C9BD38C7263B5E0D00696C37 /* linear_animation_importer.hpp in Headers */,
-				C9C7417624FC4F0500EF9516 /* animation_base.hpp in Headers */,
-				C98F29782513FAAE0076E802 /* draw_rules.hpp in Headers */,
-				C98F29792513FAAE0076E802 /* draw_target_base.hpp in Headers */,
-				C9BD38C6263B5E0D00696C37 /* keyed_object_importer.hpp in Headers */,
-				C9C741E424FC4F0500EF9516 /* weight.hpp in Headers */,
-				C9C7419C24FC4F0500EF9516 /* backboard_base.hpp in Headers */,
-				C9C7417B24FC4F0500EF9516 /* keyed_object_base.hpp in Headers */,
-				C9C741E324FC4F0500EF9516 /* skeletal_component.hpp in Headers */,
-				C9A9DA08265C50CA0005DB1F /* blend_state_base.hpp in Headers */,
-				C9A9DA0B265C50CA0005DB1F /* blend_animation_1d_base.hpp in Headers */,
-				C9A9D9FB265C50930005DB1F /* animation_state_instance.hpp in Headers */,
-				C9BD38C4263B5E0D00696C37 /* state_machine_layer_importer.hpp in Headers */,
-				C9C741A224FC4F0500EF9516 /* core_double_type.hpp in Headers */,
-				C9C7419024FC4F0500EF9516 /* cubic_detached_vertex_base.hpp in Headers */,
-				C9BD38E9263B5E4000696C37 /* state_machine_bool.hpp in Headers */,
-				C9C741AB24FC4F0500EF9516 /* container_component.hpp in Headers */,
-				C9BD38E8263B5E4000696C37 /* transition_bool_condition.hpp in Headers */,
-				C9C7418024FC4F0500EF9516 /* shape_paint_base.hpp in Headers */,
-				C9BD38C5263B5E0D00696C37 /* keyed_property_importer.hpp in Headers */,
-				C9BD38F8263B5E4000696C37 /* state_machine_instance.hpp in Headers */,
-				C9BD38E4263B5E4000696C37 /* state_transition_flags.hpp in Headers */,
-				C9BD38A8263B5D9000696C37 /* state_machine_base.hpp in Headers */,
-				C9BD3895263B5D8300696C37 /* transition_number_condition_base.hpp in Headers */,
-				0450446926B3F7A5007B25CA /* transform_constraint_base.hpp in Headers */,
-				C9C7417424FC4F0500EF9516 /* keyed_property_base.hpp in Headers */,
-				C9BD38C9263B5E0D00696C37 /* layer_state_importer.hpp in Headers */,
-				C9C7419824FC4F0500EF9516 /* bone_base.hpp in Headers */,
-				C9BD38B1263B5D9000696C37 /* exit_state_base.hpp in Headers */,
-				C9C7418124FC4F0500EF9516 /* solid_color_base.hpp in Headers */,
-				C9A9D9FA265C50930005DB1F /* blend_state_transition.hpp in Headers */,
-				C9BD38EF263B5E4000696C37 /* any_state.hpp in Headers */,
-				C9C741DB24FC4F0500EF9516 /* component.hpp in Headers */,
-				C9C7417F24FC4F0500EF9516 /* fill_base.hpp in Headers */,
-				C9AEB7E925C8903C00AE9C43 /* polygon_base.hpp in Headers */,
-				C9C741E924FC4F0500EF9516 /* cubic_weight.hpp in Headers */,
-				C9BD38B8263B5DD400696C37 /* star.hpp in Headers */,
-				C9C741A524FC4F0500EF9516 /* binary_reader.hpp in Headers */,
-				C9C7418D24FC4F0500EF9516 /* cubic_mirrored_vertex_base.hpp in Headers */,
-				C9C741B124FC4F0500EF9516 /* keyframe.hpp in Headers */,
-				C9C7417324FC4F0500EF9516 /* keyframe_color_base.hpp in Headers */,
-				C9C7419D24FC4F0500EF9516 /* drawable_base.hpp in Headers */,
-				C9A9D9F9265C50930005DB1F /* system_state_instance.hpp in Headers */,
-				C9C741E024FC4F0500EF9516 /* dependency_sorter.hpp in Headers */,
-				C9C7417C24FC4F0500EF9516 /* keyframe_double_base.hpp in Headers */,
-				C9BD38F4263B5E4000696C37 /* state_machine_input_instance.hpp in Headers */,
-				C9C7417E24FC4F0500EF9516 /* stroke_base.hpp in Headers */,
-				C9C741A424FC4F0500EF9516 /* core_bool_type.hpp in Headers */,
-				C9C741DE24FC4F0500EF9516 /* drawable.hpp in Headers */,
-				C9C7419224FC4F0500EF9516 /* path_vertex_base.hpp in Headers */,
-				C9C7417524FC4F0500EF9516 /* keyframe_base.hpp in Headers */,
-				C9C741EB24FC4F0500EF9516 /* transform_component.hpp in Headers */,
-				C9C7419124FC4F0500EF9516 /* clipping_shape_base.hpp in Headers */,
-				C9BD38EB263B5E4000696C37 /* state_machine_trigger.hpp in Headers */,
-				C9C741B524FC4F0500EF9516 /* keyframe_double.hpp in Headers */,
-				C9BD38F7263B5E4000696C37 /* layer_state.hpp in Headers */,
-				C9C741A124FC4F0500EF9516 /* core_uint_type.hpp in Headers */,
-				C9C7417124FC4F0500EF9516 /* transform_component_base.hpp in Headers */,
-				C9C7418C24FC4F0500EF9516 /* rectangle_base.hpp in Headers */,
-				04F1C94026A84BD900CEE6BE /* targeted_constraint_base.hpp in Headers */,
-				C9A9D9F4265C50930005DB1F /* blend_animation_direct.hpp in Headers */,
-				C9C7418B24FC4F0500EF9516 /* shape_base.hpp in Headers */,
-				C9C741B724FC4F0500EF9516 /* keyframe_color.hpp in Headers */,
-				C9BD38F3263B5E4000696C37 /* transition_trigger_condition.hpp in Headers */,
+				04F4624E26C4030D007CEEAB /* any_state.hpp in Headers */,
+				04F4621A26C4030D007CEEAB /* linear_animation_importer.hpp in Headers */,
+				04F4626A26C4030D007CEEAB /* shape.hpp in Headers */,
+				04F461E226C4030D007CEEAB /* stroke_base.hpp in Headers */,
+				04F4625F26C4030D007CEEAB /* solid_color.hpp in Headers */,
+				04F4627226C4030D007CEEAB /* star.hpp in Headers */,
+				04F4627F26C4030D007CEEAB /* drawable.hpp in Headers */,
 				C9C73EE224FC478900EF9516 /* RiveRuntime.h in Headers */,
-				C9C741AD24FC4F0500EF9516 /* keyed_property.hpp in Headers */,
-				C9C7417A24FC4F0500EF9516 /* linear_animation_base.hpp in Headers */,
+				04F461FA26C4030D007CEEAB /* component_base.hpp in Headers */,
+				04F4622826C4030D007CEEAB /* state_transition.hpp in Headers */,
+				04F461BB26C4030D007CEEAB /* distance_constraint_base.hpp in Headers */,
+				04F461E826C4030D007CEEAB /* gradient_stop_base.hpp in Headers */,
+				04F4622D26C4030D007CEEAB /* transition_number_condition.hpp in Headers */,
+				04F461D626C4030D007CEEAB /* blend_animation_direct_base.hpp in Headers */,
+				04F461DE26C4030D007CEEAB /* state_machine_trigger_base.hpp in Headers */,
+				04F4628326C4030D007CEEAB /* tendon.hpp in Headers */,
+				04F4621126C4030D007CEEAB /* transform_constraint.hpp in Headers */,
+				04F461DA26C4030D007CEEAB /* any_state_base.hpp in Headers */,
+				04F4627826C4030D007CEEAB /* color.hpp in Headers */,
+				04F461BD26C4030D007CEEAB /* draw_rules_base.hpp in Headers */,
+				04F4624526C4030D007CEEAB /* keyframe_double.hpp in Headers */,
+				04F461DC26C4030D007CEEAB /* state_machine_input_base.hpp in Headers */,
+				04F4622026C4030D007CEEAB /* runtime_header.hpp in Headers */,
+				04F461D326C4030D007CEEAB /* keyframe_double_base.hpp in Headers */,
+				04F461CE26C4030D007CEEAB /* blend_animation_1d_base.hpp in Headers */,
+				04F4625D26C4030D007CEEAB /* trim_path.hpp in Headers */,
+				04F4626D26C4030D007CEEAB /* polygon.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2113,6 +1987,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C9C73EE824FC478900EF9516 /* Build configuration list for PBXNativeTarget "RiveRuntimeTests" */;
 			buildPhases = (
+				04F4628E26C405A6007CEEAB /* Headers */,
 				C9C73ED824FC478900EF9516 /* Resources */,
 				C9C73ED624FC478900EF9516 /* Sources */,
 				C9C73ED724FC478900EF9516 /* Frameworks */,
@@ -2602,6 +2477,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
+				"HEADER_SEARCH_PATHS[arch=*]" = "submodules/rive-cpp/include";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2622,6 +2498,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
+				"HEADER_SEARCH_PATHS[arch=*]" = "submodules/rive-cpp/include";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Source/Renderer/RiveRenderer.mm
+++ b/Source/Renderer/RiveRenderer.mm
@@ -8,7 +8,7 @@
 
 
 #include "RiveRenderer.hpp"
-#include "renderer.hpp"
+#include "rive/renderer.hpp"
 
 using namespace rive;
 

--- a/Source/Renderer/include/RivePrivateHeaders.h
+++ b/Source/Renderer/include/RivePrivateHeaders.h
@@ -9,23 +9,23 @@
 #ifndef RivePrivateHeaders_h
 #define RivePrivateHeaders_h
 
-#import "file.hpp"
-#import "artboard.hpp"
-#import "animation.hpp"
-#import "linear_animation.hpp"
-#import "linear_animation_instance.hpp"
-#import "state_machine.hpp"
-#import "state_machine_instance.hpp"
-#import "state_machine_input.hpp"
-#import "state_machine_bool.hpp"
-#import "state_machine_number.hpp"
-#import "state_machine_trigger.hpp"
-#import "state_machine_input_instance.hpp"
-#import "layer_state.hpp"
-#import <entry_state.hpp>
-#import <any_state.hpp>
-#import <exit_state.hpp>
-#import <animation_state.hpp>
+#import "rive/file.hpp"
+#import "rive/artboard.hpp"
+#import "rive/animation/animation.hpp"
+#import "rive/animation/linear_animation.hpp"
+#import "rive/animation/linear_animation_instance.hpp"
+#import "rive/animation/state_machine.hpp"
+#import "rive/animation/state_machine_instance.hpp"
+#import "rive/animation/state_machine_input.hpp"
+#import "rive/animation/state_machine_bool.hpp"
+#import "rive/animation/state_machine_number.hpp"
+#import "rive/animation/state_machine_trigger.hpp"
+#import "rive/animation/state_machine_input_instance.hpp"
+#import "rive/animation/layer_state.hpp"
+#import <rive/animation/entry_state.hpp>
+#import <rive/animation/any_state.hpp>
+#import <rive/animation/exit_state.hpp>
+#import <rive/animation/animation_state.hpp>
 
 /*
  * RiveStateMachineInstance interface

--- a/Source/Renderer/include/RiveRenderer.hpp
+++ b/Source/Renderer/include/RiveRenderer.hpp
@@ -12,7 +12,7 @@
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CoreGraphics.h>
 #import <vector>
-#import "renderer.hpp"
+#import "rive/renderer.hpp"
 
 namespace rive
 {


### PR DESCRIPTION
- bump cpp dependency and restructure to support new rive-cpp layout
- bump cpp to support non clipping artboards
- 
took a bit longer than i had hoped... i got tripped up on getting the tests to compile, needed to include header search paths for this to work... i have no idea how this worked before, but i guess we were just importing the odd file in the .mm files that just so happend to also be on the path directly...

![image](https://user-images.githubusercontent.com/1216025/129052988-f60b6bdb-e1e1-4224-a6fb-538e62a54469.png)
