### PR TITLE
fix: use archive over build to avoid packaging swiftsourceinfo

### DIFF
--- a/.github/scripts/buildFramework.sh
+++ b/.github/scripts/buildFramework.sh
@@ -29,4 +29,4 @@ if [ -z "$CONFIGURATION" ]; then usage "Configuration is not set."; fi;
 echo -e "Build Rive Framework"
 echo -e "Configuration -> ${CONFIGURATION}, target -> ${TARGET}"
 
-xcodebuild -project RiveRuntime.xcodeproj -scheme RiveRuntime -sdk ${TARGET} -derivedDataPath build -configuration ${CONFIGURATION} | xcpretty
+xcodebuild -project RiveRuntime.xcodeproj -scheme RiveRuntime -sdk ${TARGET} -derivedDataPath archive -configuration ${CONFIGURATION} | xcpretty

--- a/.github/scripts/mergeFrameworks.sh
+++ b/.github/scripts/mergeFrameworks.sh
@@ -23,4 +23,4 @@ while [[ "$#" > 0 ]]; do case $1 in
 esac; done
 
 echo -e "Merge Rive Frameworks"
-xcodebuild -create-xcframework -framework "${BASEDIR}/build/Build/Products/${CONFIGURATION}-iphoneos/RiveRuntime.framework" -framework "${BASEDIR}/build/Build/Products/${CONFIGURATION}-iphonesimulator/RiveRuntime.framework" -output "${BASEDIR}/build/RiveRuntime.xcframework" | xcpretty
+xcodebuild -create-xcframework -framework "${BASEDIR}/archive/Build/Products/${CONFIGURATION}-iphoneos/RiveRuntime.framework" -framework "${BASEDIR}/archive/Build/Products/${CONFIGURATION}-iphonesimulator/RiveRuntime.framework" -output "${BASEDIR}/archive/RiveRuntime.xcframework" | xcpretty

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ xcuserdata/
 *.xccheckout
 
 ## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+archive/
 build/
 DerivedData/
 *.moved-aside

--- a/README.md
+++ b/README.md
@@ -35,9 +35,7 @@ git submodule update --init
 
 ## Via Pods
 
-We are in the process of getting a pod available in [cocoapods](https://cocoapods.org/).
-
-While we are working out any kinks, we are publishing our pod to a temporary github repo, which you can install by including placeholder while we finalize any kinks.
+To insatll our pod, simply add the following to [cocoapods](https://cocoapods.org/) and run `pod install`.
 
 ```ruby
 pod 'RiveRuntime'
@@ -225,6 +223,20 @@ or attach it later
 view.loopDelegate = delegate
 ```
 
+## Building & testing cocoapods locally. 
+
+- cd into checked out directory 
+- build the framework (check `build_frameworks.yml`)
+    - `sh ./.github/scripts/buildFramework.sh  -t iphoneos -c Release`
+    - `sh ./.github/scripts/buildFramework.sh  -t iphonesimulator -c Release`
+- create a podfile in the build directory.
+    - look at `podspec.txt` & replace `$RELEASE_VERSION` with something custom
+    - `cp .github/workflows/podspec.txt archive/RiveRuntime.podspec`
+
+- check its fine running `pod lib lint --allow-warnings`
+- now you can include a reference to the archive in your podfile 
+    - ` pod 'RiveRuntime', :path => '/Users/maxwelltalbot/development/rive/rive-ios/archive/'`
+
 ## Blend modes 
 
 Rive allows the artist to set blend modes on shapes to determine how they are to be merged with the rest of the animation.
@@ -236,3 +248,5 @@ For ios, hue and saturation blend modes do not match the original.
 Original | iOS             |  
 :-------------------------:|:-------------------------:
 ![Source](images/editor.png ) | ![iOS](images/ios.png)  
+
+

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ git submodule update --init
 
 ## Via Pods
 
-To insatll our pod, simply add the following to [cocoapods](https://cocoapods.org/) and run `pod install`.
+To install our pod, simply add the following to [cocoapods](https://cocoapods.org/) and run `pod install`.
 
 ```ruby
 pod 'RiveRuntime'


### PR DESCRIPTION
this should address an issue where we get this warning importing RiveRuntime 

![image](https://user-images.githubusercontent.com/1216025/142891716-85ca7ec8-fd33-4042-8c75-75aa42537efc.png)
