### PR TITLE
Test build

### DIFF
--- a/.github/workflows/build_frameworks.yml
+++ b/.github/workflows/build_frameworks.yml
@@ -61,7 +61,7 @@ jobs:
 
   build_framework:
     name: Create RiveRuntime.xcframework
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -89,7 +89,7 @@ jobs:
 
   upload_cocoapods:
     name: Update podspec repository
-    runs-on: macos-latest
+    runs-on: macos-11
     timeout-minutes: 10
     needs: [create_podspec_file, build_framework]
     steps:

--- a/.github/workflows/test_build_pod.yml
+++ b/.github/workflows/test_build_pod.yml
@@ -1,4 +1,4 @@
-name: Build test Framework
+name: Build test pod
 
 on: workflow_dispatch
 

--- a/.github/workflows/test_build_pod.yml
+++ b/.github/workflows/test_build_pod.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Add RELEASE_VERSION to env
-        run: echo "RELEASE_VERSION=0.0.9" >> $GITHUB_ENV
       - name: Read podspec.txt file
         uses: pCYSl5EDgo/cat@master
         id: podspec
@@ -84,12 +82,6 @@ jobs:
           name: RiveRuntime.podspec
       - name: Lint pod
         run: pod lib lint --allow-warnings
-      - name: Download RELEASE_VERSION
-        uses: actions/download-artifact@v2
-        with:
-          name: RELEASE_VERSION
-      - name: Add RELEASE_VERSION to env
-        run: echo "RELEASE_VERSION=$(cat RELEASE_VERSION)" >> $GITHUB_ENV
       - name: Push pod to test-ios repo
         run: |
           git status
@@ -102,3 +94,4 @@ jobs:
           git push origin v${{ env.RELEASE_VERSION }}
         env:
           API_TOKEN_GITHUB: ${{ secrets.RIVE_REPO_PAT }}
+          RELEASE_VERSION: 0.0.1

--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ view.loopDelegate = delegate
 - now you can include a reference to the archive in your podfile 
     - ` pod 'RiveRuntime', :path => '/Users/maxwelltalbot/development/rive/rive-ios/archive/'`
 
+### Testing pod build remotely
+
+There is a `test_build_pod` workflow. This workflow builds a pod & pushes it to `https://github.com/rive-app/test-ios.git`. 
+To test this pod, update the reference in your podfile to:
+    - `pod 'RiveRuntime', :git => 'https://github.com/rive-app/test-ios.git'`
+
 ## Blend modes 
 
 Rive allows the artist to set blend modes on shapes to determine how they are to be merged with the rest of the animation.


### PR DESCRIPTION
Another attempt at fixing up our ios builds. looks like we need to go for macos-11 rather than macos-latest, which will give us access to xcode 13.1! 

Also added a workflow that we can use to test remote pod builds a bit more easily. 