### PR TITLE
updated excluded archs to be arm64 i386, which is what our build comp…

### DIFF
--- a/.github/workflows/podspec.txt
+++ b/.github/workflows/podspec.txt
@@ -35,6 +35,6 @@ Pod::Spec.new do |spec|
     :tag => "v#{spec.version}"
   }
   spec.ios.vendored_frameworks = 'RiveRuntime.xcframework'
-  spec.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  spec.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  spec.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64 i386' }
+  spec.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64 i386' }
 end


### PR DESCRIPTION
…lained about for validation

fixes https://github.com/rive-app/rive-ios/runs/4507349422?check_suite_focus=true