### PR TITLE
no longer add a v in front of the version tag for rive-ios-pod, we do…

### DIFF
--- a/.github/workflows/build_frameworks.yml
+++ b/.github/workflows/build_frameworks.yml
@@ -130,8 +130,8 @@ jobs:
           git add .
           git commit -m "Update podspec repo tag:${{ env.RELEASE_VERSION }}"
           git push
-          git tag v${{ env.RELEASE_VERSION }}
-          git push origin v${{ env.RELEASE_VERSION }}
+          git tag ${{ env.RELEASE_VERSION }}
+          git push origin ${{ env.RELEASE_VERSION }}
         env:
           API_TOKEN_GITHUB: ${{ secrets.RIVE_REPO_PAT }}
       - name: Publish pod to the CocoaPods

--- a/.github/workflows/podspec.txt
+++ b/.github/workflows/podspec.txt
@@ -32,7 +32,7 @@ Pod::Spec.new do |spec|
   spec.swift_version          = '5.0'
   spec.source       = { 
     :git => "https://github.com/rive-app/rive-ios-pod.git",
-    :tag => "v#{spec.version}"
+    :tag => "#{spec.version}"
   }
   spec.ios.vendored_frameworks = 'RiveRuntime.xcframework'
 end


### PR DESCRIPTION
…nt use it anywhere else, its not good for swiftpm

rive-ios doesn't have the vx.y.z format, just the tags that we push to rive-ios-pod seemingly do. 