### PR TITLE
Removing from github installation instructions

### DIFF
--- a/.github/workflows/build_frameworks.yml
+++ b/.github/workflows/build_frameworks.yml
@@ -63,15 +63,15 @@ jobs:
         if: steps.build_iphoneos.conclusion == 'success' && steps.build_iphonesimulator.conclusion == 'success'
         name: Merge created frameworks
         run: sh ./scripts/merge_frameworks.sh -c Release
-      - id: zip
-        name: Zip the framework
+      - id: zip 
+        name: Zip the framework 
         run: zip -r RiveRuntime.xcframework.zip RiveRuntime.xcframework
         working-directory: ./archive
       - id: get_checksum
         name: Add the checksum of the zip file into our environment
         run: echo "::set-output name=checksum::$(swift package compute-checksum archive/RiveRuntime.xcframework.zip)"
       - name: Upload xcFramework
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: RiveRuntime.xcframework.zip
           path: archive/RiveRuntime.xcframework.zip

--- a/README.md
+++ b/README.md
@@ -17,29 +17,8 @@ This is the iOS runtime for [Rive](https://rive.app), currently in beta. The api
 
 # Installing rive-ios
 
-## Via github
 
-You can clone this repository and include the RiveRuntime.xcodeproj to build a dynamic or static library.
-
-When pulling down this repo, you'll need to make sure to also pull down the submodule which contains the C++ runtime that our iOS runtime is built upon. The easiest way to do this is to run this:
-
-```sh
-git clone --recurse-submodules git@github.com:rive-app/rive-ios
-```
-
-When updating, remember to also update the submodule with the same command.
-
-```sh
-git submodule update --init
-```
-
-Before you can run the examples, you need to build ...
-```sh
-cd rive-ios
-./make_dependencies.sh
-```
-
-## Via Pods
+## Via Cocoapods
 
 To install our pod, simply add the following to [cocoapods](https://cocoapods.org/) and run `pod install`.
 


### PR DESCRIPTION
Removing github based install instructions, will add swiftpm ones once I can confirm that it works

the lack of Package.swift file in the source tree caused an issue

just going to merge this. 