### PR TITLE
Remove dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,13 @@ Check out the repository, making sure to include the submodules. It is important
  `git clone --recurse-submodules git@github.com:rive-app/rive-ios.git`
 
 The package relies on skia, as well as rive-cpp in order to be built. To shorten the build cycle, we rely on compiled libraries for skia, rive & rive-skia-renderer.
-Run `./scripts/configure.sh` from the root folder to get everything that is needed to be set up. typically this will just pull down pre compiled libraries, but it may need to build the libraries if it cannot find them in the cache
+The `./scripts/configure.sh` script will download or build appropriate libraries, be sure to run configure when making changes to our rive-cpp submodule. 
 
 ### Uploading caches
 
 If you are contributing and you have access to Rives' aws environment, make you sure install `aws-cli` and configure it with your credentials. Set the `RIVE_UPLOAD_IOS_ARCHIVE` env variable to `TRUE` then you should be able to run `./scripts/configure.sh`, or `RIVE_UPLOAD_IOS_ARCHIVE=TRUE ./scripts/configure.sh` and you will upload caches when feasible. 
+
+If you run into permission issues here `aws sts get-caller-identity` can help make sure that your local developer environment is setup to talk to AWS correctly
 
 ## Changing rive-cpp/skia
 
@@ -29,10 +31,14 @@ If you make changes within the `rive-cpp` submodule you will need to compile the
 
 ## Scripts
 
-The `scripts` folder contains a few scripts to manage dependecies and perform builds.
+The `scripts` folder contains a few scripts to manage dependencies and perform builds.
 
 ## FAQ
 
-### Cannot find `Rive.h`
+### `Rive.h` file not found
 
-This is probably because of missing submodules.
+This is probably because of missing submodules. Make sure you check out rive with [submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules).
+
+### `rive/renderer.hpp` file not found
+
+This is likely because the `script/configure.py` has not been run yet.

--- a/dependencies/debug/librive.a
+++ b/dependencies/debug/librive.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fca3252da97659b42353b9085586dbf935b29a5f01602a594d04e5e66e2c1373
-size 161779848

--- a/dependencies/debug/librive_sim.a
+++ b/dependencies/debug/librive_sim.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d95f94a4c208c684d5ce41d9daed17d74fcc49b25a26f1c731c4e8f7a6dc64c
-size 160193256

--- a/dependencies/debug/librive_skia_renderer.a
+++ b/dependencies/debug/librive_skia_renderer.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f1262b49efee9997791c08b6d5281232399d20c5ff1d738e33af6cdd2191cbec
-size 1742920

--- a/dependencies/debug/librive_skia_renderer_sim.a
+++ b/dependencies/debug/librive_skia_renderer_sim.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f9de8c25f4d812f5a44c1a8d62fbad1264914284c65900a54bdbd39d34c09a69
-size 1729512

--- a/dependencies/libskia_ios.a
+++ b/dependencies/libskia_ios.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c12abce10f467eb8a512c96041ed809f29975e5fa0141a42f93af74f8c1ee08
-size 102227592

--- a/dependencies/libskia_ios_sim.a
+++ b/dependencies/libskia_ios_sim.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1db56c790c5c17c15ae7749d7d7c73ced8e8b50f3e07d8f138cf5ecf1d907a22
-size 134814936

--- a/dependencies/release/librive.a
+++ b/dependencies/release/librive.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ad256dc16a95ac43a517cd279ac884dc58cca57b782b887d62fdb21af2176e0
-size 13614992

--- a/dependencies/release/librive_sim.a
+++ b/dependencies/release/librive_sim.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74b6709111c2a155a6383b9e6af9cc8c4ee6b2a250a80609c1ef89ba218b4a36
-size 12444480

--- a/dependencies/release/librive_skia_renderer.a
+++ b/dependencies/release/librive_skia_renderer.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e9100ca47b64fdc7bc76323b50050cc2a68d95970286e6bb4687e651fdd7bd47
-size 143104

--- a/dependencies/release/librive_skia_renderer_sim.a
+++ b/dependencies/release/librive_skia_renderer_sim.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:29138281128605a63405634dd3524198798d3431d183cd3b1b1920f40df6d84e
-size 131120


### PR DESCRIPTION
Removes leftover dependency files from git. 
This was not interfering with swiftPM which is good. 

also updated docs a little bit. 