### PR TITLE
chore: update cpp dependency to latest, fixing ik problem

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,8 @@ The `./scripts/configure.sh` script will download or build appropriate libraries
 
 If you are contributing and you have access to Rives' aws environment, make you sure install `aws-cli` and configure it with your credentials. Set the `RIVE_UPLOAD_IOS_ARCHIVE` env variable to `TRUE` then you should be able to run `./scripts/configure.sh`, or `RIVE_UPLOAD_IOS_ARCHIVE=TRUE ./scripts/configure.sh` and you will upload caches when feasible. 
 
+To force a rebuild, add `rebuild` as an argument `RIVE_UPLOAD_IOS_ARCHIVE=TRUE ./scripts/configure.sh rebuild`
+
 If you run into permission issues here `aws sts get-caller-identity` can help make sure that your local developer environment is setup to talk to AWS correctly
 
 ## Changing rive-cpp/skia

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -54,7 +54,7 @@ build() {
 
 cached_build() {
     echo "Running cached build, checking $ARCHIVE_URL"
-    if curl --output /dev/null --head --silent --fail $ARCHIVE_URL
+    if curl --output /dev/null --head --silent --fail $ARCHIVE_URL && [ "$1" != "rebuild" ]
         then
             echo "$ARCHIVE_URL exists, downloading..."
             curl --output cache/$TAR_FILE_NAME $ARCHIVE_URL 
@@ -80,9 +80,9 @@ cached_build() {
 }
 
 update_dependencies () {
-    if [ "$RIVE_CPP_CLEAN" == "TRUE" ]
+    if [ "$RIVE_CPP_CLEAN" == "TRUE" ] 
         then
-            cached_build 
+            cached_build $1
         else 
             echo "Rive-cpp has changes, cannot use cached builds"
             build
@@ -90,14 +90,14 @@ update_dependencies () {
 }
 
 check_dependencies () {
-    if [ "$COMMIT_HASH" == "$CACHED_COMMIT_HASH" ] && [ "$RIVE_CPP_CLEAN" == "TRUE" ]
+    if [ "$COMMIT_HASH" == "$CACHED_COMMIT_HASH" ] && [ "$RIVE_CPP_CLEAN" == "TRUE" ] && [ "$1" != "rebuild" ]
     then 
         echo "Cache is up to date & rive_cpp is clean. no need to do anything"
     else  
-        update_dependencies
+        update_dependencies $1
     fi
 }
 
-check_dependencies
+check_dependencies $1
 
 


### PR DESCRIPTION
updates the dependency to the latest `rive-cpp` package 

#fixes 145