### PR TITLE
Roll our macos version to 12

### DIFF
--- a/.github/workflows/build_frameworks.yml
+++ b/.github/workflows/build_frameworks.yml
@@ -30,7 +30,7 @@ jobs:
 
   build_framework:
     name: Create RiveRuntime.xcframework
-    runs-on: macos-11
+    runs-on: macos-12
     needs: [determine_version]
     outputs:
       checksum: ${{steps.get_checksum.outputs.checksum}}
@@ -150,7 +150,7 @@ jobs:
 
   publish_cocoapods:
     name: Publish framework to cocoapods
-    runs-on: macos-11
+    runs-on: macos-12
     needs: [determine_version, build_framework, do_release]
     steps:
       - name: Download framework artifact

--- a/.github/workflows/test_build_pod.yml
+++ b/.github/workflows/test_build_pod.yml
@@ -30,7 +30,7 @@ jobs:
 
   build_framework:
     name: Create RiveRuntime.xcframework
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -58,7 +58,7 @@ jobs:
 
   build_pod:
     name: Update podspec repository
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 10
     needs: [create_podspec_file, build_framework]
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   run_tests:
     name: Run Rive tests
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Just good to keep up, but specifically, when we checkin bitcode, the github version of the tools must be a least as new as the "producer" -- the person uploading the new compiled code.