### PR TITLE
RiveArtboard to store rive::ArtboardInstance

### DIFF
--- a/Source/Renderer/RiveArtboard.mm
+++ b/Source/Renderer/RiveArtboard.mm
@@ -14,9 +14,9 @@
  */
 @implementation RiveArtboard
 
-- (instancetype)initWithArtboard:(rive::Artboard *)riveArtboard {
+- (instancetype)initWithArtboard:(rive::ArtboardInstance *)riveArtboard {
     if (self = [super init]) {
-        _artboard = riveArtboard;
+        _artboardInstance = riveArtboard;
         return self;
     } else {
         return NULL;
@@ -24,12 +24,12 @@
 }
 
 - (NSInteger)animationCount {
-    return _artboard->animationCount();
+    return _artboardInstance->animationCount();
 }
 
 // Returns the first animation in the artboard, or null if it has none
 - (RiveLinearAnimation *)firstAnimation:(NSError**) error {
-    rive::LinearAnimation *animation = _artboard->firstAnimation();
+    rive::LinearAnimation *animation = _artboardInstance->firstAnimation();
     if (animation == nullptr) {
         *error = [NSError errorWithDomain:RiveErrorDomain code:RiveNoAnimations userInfo:@{NSLocalizedDescriptionKey: @"No Animations found.", @"name": @"NoAnimations"}];
         return nil;
@@ -45,12 +45,12 @@
         *error = [NSError errorWithDomain:RiveErrorDomain code:RiveNoAnimationFound userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat: @"No Animation found at index %ld.", (long)index], @"name": @"NoAnimationFound"}];
         return nil;
     }
-    return [[RiveLinearAnimation alloc] initWithAnimation: _artboard->animation(index)];
+    return [[RiveLinearAnimation alloc] initWithAnimation: _artboardInstance->animation(index)];
 }
 
 - (RiveLinearAnimation *)animationFromName:(NSString *)name error:(NSError**) error {
     std::string stdName = std::string([name UTF8String]);
-    rive::LinearAnimation *animation = _artboard->animation(stdName);
+    rive::LinearAnimation *animation = _artboardInstance->animation(stdName);
     if (animation == nullptr) {
         *error = [NSError errorWithDomain:RiveErrorDomain code:RiveNoAnimationFound userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat: @"No Animation found with name %@.", name], @"name": @"NoAnimationFound"}];
         return nil;
@@ -68,11 +68,11 @@
 
 // Returns the number of state machines in the artboard
 - (NSInteger)stateMachineCount {
-    return _artboard->stateMachineCount();
+    return _artboardInstance->stateMachineCount();
 }
 
 - (RiveStateMachine *)firstStateMachine:(NSError**)error {
-    rive::StateMachine *stateMachine = _artboard->firstStateMachine();
+    rive::StateMachine *stateMachine = _artboardInstance->firstStateMachine();
     if (stateMachine == nullptr) {
         *error = [NSError errorWithDomain:RiveErrorDomain code:RiveNoStateMachines userInfo:@{NSLocalizedDescriptionKey: @"No State Machines found.", @"name": @"NoStateMachines"}];
         return nil;
@@ -88,13 +88,13 @@
         *error = [NSError errorWithDomain:RiveErrorDomain code:RiveNoStateMachineFound userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat: @"No State Machine found at index %ld.", (long)index], @"name": @"NoStateMachineFound"}];
         return nil;
     }
-    return [[RiveStateMachine alloc] initWithStateMachine: _artboard->stateMachine(index)];
+    return [[RiveStateMachine alloc] initWithStateMachine: _artboardInstance->stateMachine(index)];
 }
 
 // Returns a state machine with the given name, or null if none exists
 - (RiveStateMachine *)stateMachineFromName:(NSString *)name error:(NSError**)error {
     std::string stdName = std::string([name UTF8String]);
-    rive::StateMachine *machine = _artboard->stateMachine(stdName);
+    rive::StateMachine *machine = _artboardInstance->stateMachine(stdName);
     if (machine == nullptr) {
         *error = [NSError errorWithDomain:RiveErrorDomain code:RiveNoStateMachineFound userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat: @"No State Machine found with name %@.", name], @"name": @"NoStateMachineFound"}];
         return nil;
@@ -112,33 +112,25 @@
 
 
 - (void)advanceBy:(double)elapsedSeconds {
-    _artboard->advance(elapsedSeconds);
+    _artboardInstance->advance(elapsedSeconds);
 }
 
 - (void)draw:(RiveRenderer *)renderer {
-    _artboard->draw([renderer renderer]);
+    _artboardInstance->draw([renderer renderer]);
 }
 
 - (NSString *)name {
-    std::string str = _artboard->name();
+    std::string str = _artboardInstance->name();
     return [NSString stringWithCString:str.c_str() encoding:[NSString defaultCStringEncoding]];
 }
 
 - (CGRect)bounds {
-    rive::AABB aabb = _artboard->bounds();
+    rive::AABB aabb = _artboardInstance->bounds();
     return CGRectMake(aabb.minX, aabb.minY, aabb.width(), aabb.height());
 }
 
-// Creates an instance of the artboard
-- (RiveArtboard *)instance {
-    std::unique_ptr<rive::Artboard> instance = _artboard->instance();
-    return [[RiveArtboard alloc] initWithArtboard: instance.release()];
-}
-
 - (void)dealloc {
-     if (_artboard->isInstance()) {
-       delete _artboard;
-     }
+     delete _artboardInstance;
 }
 
 @end

--- a/Source/Renderer/RiveFile.mm
+++ b/Source/Renderer/RiveFile.mm
@@ -152,13 +152,13 @@
 }
 
 - (RiveArtboard *)artboard:(NSError**)error {
-    rive::Artboard *artboard = riveFile->artboard();
+    auto artboard = riveFile->artboardDefault();
     if (artboard == nullptr) {
         *error = [NSError errorWithDomain:RiveErrorDomain code:RiveNoArtboardsFound userInfo:@{NSLocalizedDescriptionKey: @"No Artboards Found.", @"name": @"NoArtboardsFound"}];
         return nil;
     }
     else {
-        return [[RiveArtboard alloc] initWithArtboard: artboard];
+        return [[RiveArtboard alloc] initWithArtboard: artboard.release()];
     }
 }
 
@@ -167,22 +167,22 @@
 }
 
 - (RiveArtboard *)artboardFromIndex:(NSInteger)index error:(NSError**)error {
-    if (index >= [self artboardCount]) {
+    auto artboard = riveFile->artboardAt(index);
+    if (artboard == nullptr) {
         *error = [NSError errorWithDomain:RiveErrorDomain code:RiveNoArtboardFound userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat: @"No Artboard Found at index %ld.", (long)index], @"name": @"NoArtboardFound"}];
         return nil;
     }
-    return [[RiveArtboard alloc]
-            initWithArtboard: reinterpret_cast<rive::Artboard *>(riveFile->artboard(index))];
+    return [[RiveArtboard alloc] initWithArtboard: artboard.release()];
 }
 
 - (RiveArtboard *)artboardFromName:(NSString *)name error:(NSError**)error {
     std::string stdName = std::string([name UTF8String]);
-    rive::Artboard *artboard = riveFile->artboard(stdName);
+    auto artboard = riveFile->artboardNamed(stdName);
     if (artboard == nullptr) {
         *error = [NSError errorWithDomain:RiveErrorDomain code:RiveNoArtboardFound userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat: @"No Artboard Found with name %@.", name], @"name": @"NoArtboardFound"}];
         return nil;
     } else {
-        return [[RiveArtboard alloc] initWithArtboard: artboard];
+        return [[RiveArtboard alloc] initWithArtboard: artboard.release()];
     }
 }
 

--- a/Source/Renderer/RiveLinearAnimation.mm
+++ b/Source/Renderer/RiveLinearAnimation.mm
@@ -72,7 +72,7 @@
 }
 
 - (void)apply:(float)time to:(RiveArtboard *)artboard {
-    animation->apply(artboard.artboard, time);
+    animation->apply(artboard.artboardInstance, time);
 }
 
 - (int)loop {

--- a/Source/Renderer/RiveLinearAnimationInstance.mm
+++ b/Source/Renderer/RiveLinearAnimationInstance.mm
@@ -19,7 +19,7 @@
 - (instancetype)initWithAnimation:(const rive::LinearAnimation *)riveAnimation
                          artboard:(RiveArtboard *)artboard {
     if (self = [super init]) {
-        instance = new rive::LinearAnimationInstance(riveAnimation, artboard.artboard);
+        instance = new rive::LinearAnimationInstance(riveAnimation, artboard.artboardInstance);
         return self;
     } else {
         return nil;

--- a/Source/Renderer/RiveStateMachineInstance.mm
+++ b/Source/Renderer/RiveStateMachineInstance.mm
@@ -29,7 +29,7 @@
                             artboard:(RiveArtboard *)artboard {
     if (self = [super init]) {
         self->stateMachine = stateMachine;
-        instance = new rive::StateMachineInstance(stateMachine, artboard.artboard);
+        instance = new rive::StateMachineInstance(stateMachine, artboard.artboardInstance);
         _inputs = [[NSMutableDictionary alloc] init];
         return self;
     } else {

--- a/Source/Renderer/include/RiveArtboard.h
+++ b/Source/Renderer/include/RiveArtboard.h
@@ -41,9 +41,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)advanceBy:(double)elapsedSeconds;
 - (void)draw:(RiveRenderer *)renderer;
 
-// Creates an instance of the artboard
-- (RiveArtboard *)instance;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/Renderer/include/RivePrivateHeaders.h
+++ b/Source/Renderer/include/RivePrivateHeaders.h
@@ -92,8 +92,8 @@
  * RiveArtboard interface
  */
 @interface RiveArtboard ()
-@property (nonatomic, readonly) rive::Artboard* artboard;
--(instancetype) initWithArtboard:(rive::Artboard *) riveArtboard;
+@property (nonatomic, readonly) rive::ArtboardInstance* artboardInstance;
+-(instancetype) initWithArtboard:(rive::ArtboardInstance *) riveArtboard;
 @end
 
 /*

--- a/Source/Views/RiveView.swift
+++ b/Source/Views/RiveView.swift
@@ -397,8 +397,7 @@ extension RiveView {
             fatalError("No animations in the file.")
         }
         
-        // Make an instance of the artboard and use that
-        self._artboard = artboard.instance()
+        self._artboard = artboard
         
         // Start the animation loop
         if autoPlay {

--- a/Source/Views/rive_renderer_view.mm
+++ b/Source/Views/rive_renderer_view.mm
@@ -176,7 +176,7 @@ sk_sp<SkSurface> SkMtkViewToSurface(MTKView *mtkView,
 }
 
 - (void)drawWithArtboard:(RiveArtboard *)artboard {
-  [artboard artboard]->draw(_renderer);
+  [artboard artboardInstance]->draw(_renderer);
 }
 
 - (void)drawRive:(CGRect)rect atSize:(CGSize)size {

--- a/Tests/StateMachineInstanceTest.mm
+++ b/Tests/StateMachineInstanceTest.mm
@@ -24,8 +24,7 @@
     RiveFile* file = [Util loadTestFile:@"state_machine_configurations" error:nil];
     
     RiveArtboard* artboard = [file artboard:nil];
-    RiveArtboard* abInstance = [artboard instance];
-    RiveStateMachineInstance* stateMachineInstance  = [[artboard stateMachineFromName:@"nothing" error:nil] instanceWithArtboard:abInstance];
+    RiveStateMachineInstance* stateMachineInstance  = [[artboard stateMachineFromName:@"nothing" error:nil] instanceWithArtboard:artboard];
 
     XCTAssertEqual([stateMachineInstance inputCount], 0);
 }
@@ -37,8 +36,7 @@
     RiveFile* file = [Util loadTestFile:@"state_machine_configurations" error:nil];
     
     RiveArtboard* artboard = [file artboard:nil];
-    RiveArtboard* abInstance = [artboard instance];
-    RiveStateMachineInstance* stateMachineInstance  = [[artboard stateMachineFromName:@"number_input" error:nil] instanceWithArtboard:abInstance];
+    RiveStateMachineInstance* stateMachineInstance  = [[artboard stateMachineFromName:@"number_input" error:nil] instanceWithArtboard:artboard];
 
     XCTAssertEqual([stateMachineInstance inputCount], 1);
     
@@ -61,8 +59,7 @@
     RiveFile* file = [Util loadTestFile:@"state_machine_configurations" error:nil];
     
     RiveArtboard* artboard = [file artboard:nil];
-    RiveArtboard* abInstance = [artboard instance];
-    RiveStateMachineInstance* stateMachineInstance = [[artboard stateMachineFromName:@"boolean_input" error:nil] instanceWithArtboard:abInstance];
+    RiveStateMachineInstance* stateMachineInstance = [[artboard stateMachineFromName:@"boolean_input" error:nil] instanceWithArtboard:artboard];
 
     XCTAssertEqual([stateMachineInstance inputCount], 1);
     
@@ -88,8 +85,7 @@
     RiveFile* file = [Util loadTestFile:@"state_machine_configurations" error:nil];
     
     RiveArtboard* artboard = [file artboard:nil];
-    RiveArtboard* abInstance = [artboard instance];
-    RiveStateMachineInstance* stateMachineInstance  = [[artboard stateMachineFromName:@"trigger_input" error:nil] instanceWithArtboard:abInstance];
+    RiveStateMachineInstance* stateMachineInstance  = [[artboard stateMachineFromName:@"trigger_input" error:nil] instanceWithArtboard:artboard];
 
     XCTAssertEqual([stateMachineInstance inputCount], 1);
     
@@ -111,8 +107,7 @@
     RiveFile* file = [Util loadTestFile:@"state_machine_configurations" error:nil];
     
     RiveArtboard* artboard = [file artboard:nil];
-    RiveArtboard* abInstance = [artboard instance];
-    RiveStateMachineInstance* stateMachineInstance = [[artboard stateMachineFromName:@"mixed" error:nil] instanceWithArtboard:abInstance];
+    RiveStateMachineInstance* stateMachineInstance = [[artboard stateMachineFromName:@"mixed" error:nil] instanceWithArtboard:artboard];
 
     XCTAssertEqual([stateMachineInstance inputCount], 6);
     NSArray * target = [NSArray arrayWithObjects:@"zero", @"off", @"trigger", @"two_point_two", @"on", @"three", nil];


### PR DESCRIPTION
This change's the iOS RiveArtboard to store a rive::ArtboardInstance

It was always creating anyways (by calling artboard->instance()) but now we use the new File apis to create it directly.

Future: switch over to creating animation and statemachine instances directly as well...