### PR TITLE
Fix computing seconds

### DIFF
--- a/Source/Renderer/RiveLinearAnimation.mm
+++ b/Source/Renderer/RiveLinearAnimation.mm
@@ -57,14 +57,16 @@
 }
 
 - (float)effectiveDurationInSeconds {
-    return [self effectiveDuration] / [self fps];
+    float ifps = 1.0 / animation->fps();
+    return [self effectiveDuration] * ifps;
 }
 
 - (float)endTime {
+    float ifps = 1.0 / animation->fps();
     if (animation->enableWorkArea()){
-        return animation->workEnd()/animation->fps();
+        return animation->workEnd() * ifps;
     }
-    return animation->duration()/animation->fps();
+    return animation->duration() * ifps;
 }
 
 - (NSInteger)fps {

--- a/Tests/RiveAnimationConfigurationsTest.mm
+++ b/Tests/RiveAnimationConfigurationsTest.mm
@@ -108,17 +108,15 @@
     XCTAssertEqual([animation workEnd], 50);
 
     // These calculations may have some floating error, as they are approximate
+    const float accuracy = 0.0000001;
 
-    // these are currently failing: TODO: fix tme
-    if (false) {
-        // seconds = duation / fps = 20/60
-        float secs = 20.0 / 60.0;
-        XCTAssertEqual([animation effectiveDurationInSeconds], secs);
+    // seconds = duation / fps = 20/60
+    const float secs = 20.0 / 60.0;
+    XCTAssertEqualWithAccuracy([animation effectiveDurationInSeconds], secs, accuracy);
 
-        // time = effectiveDuration / fps = 50/60
-        float time = 50.0 / 60.0;
-        XCTAssertEqual([animation endTime], time);
-    }
+    // time = effectiveDuration / fps = 50/60
+    const float time = 50.0 / 60.0;
+    XCTAssertEqualWithAccuracy([animation endTime], time, accuracy);
 }
 
 /*


### PR DESCRIPTION
The earlier code was calling int/int -- which gave a truncated, integer result. Switching to floating point math.