### PR TITLE
Maint: Remove major version flag

### DIFF
--- a/.github/workflows/Package.swift.template
+++ b/.github/workflows/Package.swift.template
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "RiveRuntime",
-    platforms: [.iOS("11.0")],
+    platforms: [.iOS("14.0")],
     products: [
         .library(
             name: "RiveRuntime",

--- a/.github/workflows/RiveRuntime.podspec.template
+++ b/.github/workflows/RiveRuntime.podspec.template
@@ -27,8 +27,8 @@ Pod::Spec.new do |spec|
     LICENSE
   }
   spec.authors = { "Luigi Rosso" => "luigi@rive.app" }
-  spec.platform               = :ios, '11.0'
-  spec.ios.deployment_target  = '11.0'
+  spec.platform               = :ios, '14.0'
+  spec.ios.deployment_target  = '14.0'
   spec.swift_version          = '5.0'
   spec.source       = { 
     :http => "https://github.com/rive-app/rive-ios/releases/download/$RELEASE_VERSION/RiveRuntime.xcframework.zip",

--- a/.github/workflows/build_frameworks.yml
+++ b/.github/workflows/build_frameworks.yml
@@ -22,7 +22,7 @@ jobs:
         working-directory: ./.github/release
       - id: determine_version
         name: Get Version
-        run: npm run release -- major --ci --release-version | tail -n 1 > RELEASE_VERSION
+        run: npm run release -- --ci --release-version | tail -n 1 > RELEASE_VERSION
         working-directory: ./.github/release
         env:
           GITHUB_TOKEN: ${{ secrets.RIVE_REPO_PAT }}
@@ -146,7 +146,7 @@ jobs:
           name: RiveRuntime.xcframework.zip
           path: archive/
       - name: Bump version number, update changelog, push and tag
-        run: npm run release -- major --ci
+        run: npm run release -- --ci
         working-directory: ./.github/release
         env:
           GITHUB_TOKEN: ${{ secrets.RIVE_REPO_PAT }}


### PR DESCRIPTION
We should figure out a way (i.e commit message keyword?) for release-it to do a patch, minor, or major version bump so we don't have to do this dance with release-it.