### PR TITLE
Roll cpp forward -- no more BinaryReader

### DIFF
--- a/Source/Renderer/RiveFile.mm
+++ b/Source/Renderer/RiveFile.mm
@@ -9,11 +9,6 @@
 #import <Rive.h>
 #import <RivePrivateHeaders.h>
 
-@interface RiveFile ()
-
-- (rive::BinaryReader) getReader:(UInt8 *)bytes byteLength:(UInt64)length;
-
-@end
 
 /*
  * RiveFile


### PR DESCRIPTION
1. Roll cpp forward (and rebuild caches)
2. Update objective-c to remove references to BinaryReader (api change)