### PR TITLE
RiveScene as common base

### DIFF
--- a/RiveRuntime.xcodeproj/project.pbxproj
+++ b/RiveRuntime.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		04BE5430264D1F4100427B39 /* LayerState.h in Headers */ = {isa = PBXBuildFile; fileRef = 04BE542F264D1F4100427B39 /* LayerState.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		04BE5434264D267900427B39 /* LayerState.mm in Sources */ = {isa = PBXBuildFile; fileRef = 04BE5431264D243D00427B39 /* LayerState.mm */; };
 		04BE5436264D2A7500427B39 /* RivePrivateHeaders.h in Headers */ = {isa = PBXBuildFile; fileRef = 04BE5435264D2A7500427B39 /* RivePrivateHeaders.h */; };
+		27E49738283FE46800559CAB /* RiveScene.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E49737283FE46800559CAB /* RiveScene.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		27E4973A283FE47600559CAB /* RiveScene.mm in Sources */ = {isa = PBXBuildFile; fileRef = 27E49739283FE47600559CAB /* RiveScene.mm */; };
 		2A7079352726277C00C035A1 /* rive_renderer_view.hh in Headers */ = {isa = PBXBuildFile; fileRef = 2A7079342726277C00C035A1 /* rive_renderer_view.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		2A707937272628AD00C035A1 /* rive_renderer_view.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2A707936272628AD00C035A1 /* rive_renderer_view.mm */; };
 		C34609FC27FF9114002DBCB7 /* RiveFile+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34609FB27FF9114002DBCB7 /* RiveFile+Extensions.swift */; };
@@ -105,6 +107,8 @@
 		04BE542F264D1F4100427B39 /* LayerState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LayerState.h; sourceTree = "<group>"; };
 		04BE5431264D243D00427B39 /* LayerState.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LayerState.mm; sourceTree = "<group>"; };
 		04BE5435264D2A7500427B39 /* RivePrivateHeaders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RivePrivateHeaders.h; sourceTree = "<group>"; };
+		27E49737283FE46800559CAB /* RiveScene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RiveScene.h; sourceTree = "<group>"; };
+		27E49739283FE47600559CAB /* RiveScene.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RiveScene.mm; sourceTree = "<group>"; };
 		2A7079342726277C00C035A1 /* rive_renderer_view.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = rive_renderer_view.hh; sourceTree = "<group>"; };
 		2A707936272628AD00C035A1 /* rive_renderer_view.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = rive_renderer_view.mm; sourceTree = "<group>"; };
 		C34609FB27FF9114002DBCB7 /* RiveFile+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RiveFile+Extensions.swift"; sourceTree = "<group>"; };
@@ -147,6 +151,7 @@
 		046FB801264EB632000129B1 /* include */ = {
 			isa = PBXGroup;
 			children = (
+				27E49737283FE46800559CAB /* RiveScene.h */,
 				046FB7EC264EAA60000129B1 /* RiveArtboard.h */,
 				046FB7E7264EAA5F000129B1 /* RiveFile.h */,
 				046FB7E1264EAA5E000129B1 /* RiveLinearAnimationInstance.h */,
@@ -202,6 +207,7 @@
 		C9BD3927263B64B100696C37 /* Renderer */ = {
 			isa = PBXGroup;
 			children = (
+				27E49739283FE47600559CAB /* RiveScene.mm */,
 				046FB801264EB632000129B1 /* include */,
 				046FB7E2264EAA5E000129B1 /* RiveArtboard.mm */,
 				046FB7EF264EAA60000129B1 /* RiveFile.mm */,
@@ -291,6 +297,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				046FB7F7264EAA60000129B1 /* RiveFile.h in Headers */,
+				27E49738283FE46800559CAB /* RiveScene.h in Headers */,
 				046FB7FC264EAA61000129B1 /* RiveArtboard.h in Headers */,
 				2A7079352726277C00C035A1 /* rive_renderer_view.hh in Headers */,
 				046FB800264EAA61000129B1 /* RiveStateMachineInstance.h in Headers */,
@@ -424,6 +431,7 @@
 				C3E2B580282F242400A8651B /* RiveStateMachineInstance+Extensions.swift in Sources */,
 				046FB7F5264EAA60000129B1 /* RiveSMIInput.mm in Sources */,
 				C3468E5A27ECC7C6008652FD /* RiveViewModel.swift in Sources */,
+				27E4973A283FE47600559CAB /* RiveScene.mm in Sources */,
 				C3745FD3282BFAB90087F4AF /* FPSCounterView.swift in Sources */,
 				C9C741F524FC510200EF9516 /* Rive.mm in Sources */,
 				046FB7F8264EAA60000129B1 /* RiveStateMachineInstance.mm in Sources */,

--- a/Source/Renderer/RiveArtboard.mm
+++ b/Source/Renderer/RiveArtboard.mm
@@ -22,6 +22,13 @@
     }
 }
 
+- (RiveStateMachineInstance * __nullable)defaultStateMachine {
+    if (auto dsm = _artboardInstance->defaultStateMachine()) {
+        return [[RiveStateMachineInstance alloc] initWithStateMachine: dsm.release()];
+    }
+    return nil;
+}
+
 - (NSInteger)animationCount {
     return _artboardInstance->animationCount();
 }

--- a/Source/Renderer/RiveLinearAnimationInstance.mm
+++ b/Source/Renderer/RiveLinearAnimationInstance.mm
@@ -59,11 +59,6 @@
     return instance->didLoop();
 }
 
-- (NSString *)name {
-    std::string str = instance->name();
-    return [NSString stringWithCString:str.c_str() encoding:[NSString defaultCStringEncoding]];
-}
-
 - (void)dealloc {
     delete instance;
 }

--- a/Source/Renderer/RiveScene.mm
+++ b/Source/Renderer/RiveScene.mm
@@ -1,0 +1,43 @@
+//
+//  RiveLinearAnimationInstance.m
+//  RiveRuntime
+//
+//  Created by Maxwell Talbot on 5/14/21.
+//  Copyright © 2021 Rive. All rights reserved.
+//
+
+#import <Rive.h>
+#import <RivePrivateHeaders.h>
+
+@implementation RiveScene {
+    rive::Scene *instance;
+}
+
+- (instancetype)initWithScene:(rive::Scene *)scene {
+    if (self = [super init]) {
+        instance = scene;
+        return self;
+    } else {
+        return nil;
+    }
+}
+
+- (NSString *)name {
+    std::string str = instance->name();
+    return [NSString stringWithCString:str.c_str() encoding:[NSString defaultCStringEncoding]];
+}
+
+- (CGRect)bounds {
+    rive::AABB aabb = instance->bounds();
+    return CGRectMake(aabb.minX, aabb.minY, aabb.width(), aabb.height());
+}
+
+- (void)draw:(RiveRenderer *)renderer {
+    instance->draw([renderer renderer]);
+}
+
+- (void)dealloc {
+    delete instance;
+}
+
+@end

--- a/Source/Renderer/RiveStateMachineInstance.mm
+++ b/Source/Renderer/RiveStateMachineInstance.mm
@@ -96,11 +96,6 @@
     }
 }
 
-- (NSString *)name {
-    std::string str = instance->name();
-    return [NSString stringWithCString:str.c_str() encoding:[NSString defaultCStringEncoding]];
-}
-
 - (NSInteger)inputCount{
     return instance->inputCount();
 }

--- a/Source/Renderer/include/RiveArtboard.h
+++ b/Source/Renderer/include/RiveArtboard.h
@@ -12,6 +12,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class RiveLinearAnimationInstance;
+@class RiveScene;
 @class RiveStateMachineInstance;
 @class RiveRenderer;
 
@@ -21,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)name;
 - (CGRect)bounds;
+
+- (RiveStateMachineInstance * __nullable)defaultStateMachine;
 
 - (NSInteger)animationCount;
 - (NSArray<NSString *> *)animationNames;

--- a/Source/Renderer/include/RiveFile.h
+++ b/Source/Renderer/include/RiveFile.h
@@ -14,6 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class RiveScene;
 @class RiveArtboard;
 @protocol RiveFileDelegate;
 

--- a/Source/Renderer/include/RiveLinearAnimationInstance.h
+++ b/Source/Renderer/include/RiveLinearAnimationInstance.h
@@ -11,13 +11,14 @@
 #define rive_linear_animation_instance_h
 
 #import <Foundation/Foundation.h>
+#import <RiveScene.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 /*
  * RiveLinearAnimationInstance
  */
-@interface RiveLinearAnimationInstance : NSObject
+@interface RiveLinearAnimationInstance : RiveScene
 
 - (float)time;
 - (void)setTime:(float) time;
@@ -29,7 +30,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (int)loop;
 - (void)loop:(int)loopMode;
 - (bool)didLoop;
-- (NSString *)name;
 
 - (NSInteger)fps;
 - (NSInteger)workStart;

--- a/Source/Renderer/include/RiveScene.h
+++ b/Source/Renderer/include/RiveScene.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Rive
+ */
+
+#ifndef rive_scene_h
+#define rive_scene_h
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RiveScene : NSObject
+
+- (NSString *)name;
+- (CGRect)bounds;
+- (void)draw:(RiveRenderer *)renderer;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* rive_scene_h */

--- a/Source/Renderer/include/RiveStateMachineInstance.h
+++ b/Source/Renderer/include/RiveStateMachineInstance.h
@@ -11,11 +11,10 @@
 #define rive_state_machine_instance_h
 
 #import <Foundation/Foundation.h>
-
+#import <RiveScene.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class RiveStateMachine;
 @class RiveSMIInput;
 @class RiveSMIBool;
 @class RiveSMITrigger;
@@ -25,8 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*
  * RiveStateMachineInstance
  */
-@interface RiveStateMachineInstance : NSObject
-- (NSString* )name;
+@interface RiveStateMachineInstance : RiveScene
 - (bool)advanceBy: (double)elapsedSeconds;
 - (const RiveSMIBool *)getBool:(NSString*)name;
 - (const RiveSMITrigger *)getTrigger:(NSString*)name;

--- a/Source/Views/rive_renderer_view.mm
+++ b/Source/Views/rive_renderer_view.mm
@@ -246,7 +246,7 @@ sk_sp<SkSurface> SkMtkViewToSurface(MTKView *mtkView,
     rive::Vec2D frameLocation(touchLocation.x, touchLocation.y);
     rive::Vec2D convertedLocation = inverse * frameLocation;
     
-    return CGPointMake(convertedLocation.x(), convertedLocation.y());
+    return CGPointMake(convertedLocation.x, convertedLocation.y);
 }
 
 @end


### PR DESCRIPTION
1. name (already existed separately in animation and machine)
2. draw (new)
3. bounds (new)

This just exposes the beginnings of what is exposed on the cpp side, where Scene has lost of other APIs.
Those can be addressed later

Also, expose the notion that an Artboard has a **default** statemachine.
