### PR TITLE
Global caching for RiveFiles

### DIFF
--- a/Source/Components/RiveModel.swift
+++ b/Source/Components/RiveModel.swift
@@ -9,21 +9,35 @@
 import Foundation
 
 open class RiveModel: ObservableObject {
-    internal private(set) var riveFile: RiveFile
+    private let fileUUID: UInt
+    
+    internal static var fileCache: RiveFileCache = RiveFileCache()
+    internal weak var riveFile: RiveFile! { RiveModel.fileCache.reference(with: fileUUID)!.file }
+    
     public private(set) var artboard: RiveArtboard!
     public internal(set) var stateMachine: RiveStateMachineInstance?
     public internal(set) var animation: RiveLinearAnimationInstance?
     
     public init(riveFile: RiveFile) {
-        self.riveFile = riveFile
+        fileUUID = riveFile.uuid
+        RiveModel.fileCache.add(riveFile)
     }
     
     public init(fileName: String) throws {
-        riveFile = try RiveFile(name: fileName)
+        let file = try RiveFile(name: fileName)
+        fileUUID = file.uuid
+        RiveModel.fileCache.add(file)
     }
     
     public init(webURL: String, delegate: RiveFileDelegate) {
-        riveFile = RiveFile(httpUrl: webURL, with: delegate)!
+        let file = RiveFile(httpUrl: webURL, with: delegate)!
+        fileUUID = file.uuid
+        RiveModel.fileCache.add(file)
+    }
+    
+    deinit {
+        RiveModel.fileCache.remove(riveFile)
+        //print("RiveView deinit")
     }
     
     // MARK: - Setters
@@ -89,5 +103,57 @@ open class RiveModel: ObservableObject {
         case invalidStateMachine(name: String), invalidStateMachine(index: Int)
         case invalidAnimation(name: String), invalidAnimation(index: Int)
         case invalidArtboard(name: String), invalidArtboard(index: Int), invalidArtboard(message: String)
+    }
+}
+
+internal class RiveFileReference {
+    var referenceCount: Int = 0
+    var file: RiveFile
+    
+    init(file: RiveFile) {
+        self.file = file
+    }
+}
+
+internal class RiveFileCache {
+    var fileReferences: [RiveFileReference] = []
+    
+    subscript(index: Int) -> RiveFile { fileReferences[index].file }
+    
+    func reference(with uuid: UInt) -> RiveFileReference? {
+        return fileReferences.first { $0.file.uuid == uuid }
+    }
+    
+    /// Adds this file to the cache if its uuid is unique. If not it increases that cached file's reference count
+    func add(_ file: RiveFile) {
+        // The RiveFile is already in the cache so we just bump the reference count
+        if let cachedRef = (fileReferences.first { $0.file.uuid == file.uuid }) {
+            cachedRef.referenceCount += 1
+            print("RiveFile UUID: \(cachedRef.file.uuid) referenced -- References: \(cachedRef.referenceCount) -- Files cached: \(fileReferences.count)")
+        }
+        // The RiveFile is new so we add it to the cache
+        else {
+            let reference = RiveFileReference(file: file)
+            reference.referenceCount = 1
+            fileReferences.append(reference)
+            print("RiveFile UUID: \(reference.file.uuid) added -- Files cached: \(fileReferences.count)")
+        }
+    }
+    
+    /// Decreases the reference count of this file. Removes this file from the cache if its reference count is 0
+    func remove(_ file: RiveFile) {
+        if let cachedRef = (fileReferences.first { $0.file.uuid == file.uuid }) {
+            cachedRef.referenceCount -= 1
+            
+            // The cached RiveFile has nothing referencing it so it will be removed
+            if cachedRef.referenceCount <= 0 {
+                fileReferences.removeAll { $0.file.uuid == file.uuid }
+                print("RiveFile UUID: \(file.uuid) removed -- Files cached: \(fileReferences.count)")
+            }
+            // The cached RiveFile has references to it
+            else {
+                print("RiveFile UUID: \(file.uuid) unreferenced -- References: \(cachedRef.referenceCount) -- Files cached: \(fileReferences.count)")
+            }
+        }
     }
 }

--- a/Source/Renderer/RiveFile.mm
+++ b/Source/Renderer/RiveFile.mm
@@ -24,6 +24,7 @@ static rive::SkiaFactory gFactory;
 
 - (nullable instancetype)initWithByteArray:(NSArray *)array error:(NSError**)error {
     if (self = [super init]) {
+        _uuid = [array hash];
         UInt8* bytes;
         @try {
             bytes = (UInt8*)calloc(array.count, sizeof(UInt64));
@@ -48,6 +49,9 @@ static rive::SkiaFactory gFactory;
 
 - (nullable instancetype)initWithBytes:(UInt8 *)bytes byteLength:(UInt64)length error:(NSError**)error {
     if (self = [super init]) {
+        auto data = [[NSData alloc] initWithBytes:bytes length:length];
+        _uuid = [data hash];
+        
         BOOL ok = [self import:bytes byteLength:length error:error];
         if (!ok) {
             return nil;
@@ -82,6 +86,7 @@ static rive::SkiaFactory gFactory;
 - (nullable instancetype)initWithHttpUrl:(NSString *)url withDelegate:(id<RiveFileDelegate>)delegate {
     self.isLoaded = false;
     if (self = [super init]) {
+        _uuid = [url hash];
         self.delegate = delegate;
         // Set up the http download task
         NSURL *URL = [NSURL URLWithString:url];

--- a/Source/Renderer/include/RiveFile.h
+++ b/Source/Renderer/include/RiveFile.h
@@ -31,6 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Delegate for calling when a file has finished loading
 @property id delegate;
 
+@property NSUInteger uuid;
+
 - (nullable instancetype)initWithByteArray:(NSArray *)bytes error:(NSError**)error;
 - (nullable instancetype)initWithBytes:(UInt8 *)bytes byteLength:(UInt64)length error:(NSError**)error;
 - (nullable instancetype)initWithResource:(NSString *)resourceName withExtension:(NSString *)extension error:(NSError**)error;


### PR DESCRIPTION
The changes in this PR give the high level RiveModel a caching feature that allows a file, once loaded, to be reused when it's needed elsewhere rather than being loaded again. 