### PR TITLE
User provided Bundle

### DIFF
--- a/Example-iOS/Source/lib/utility.swift
+++ b/Example-iOS/Source/lib/utility.swift
@@ -10,8 +10,8 @@ import SwiftUI
 import RiveRuntime
 
 @available(*, deprecated, message: "Use method in RiveFile+Extensions instead")
-func getBytes(resourceName: String, resourceExt: String=".riv") -> [UInt8] {
-    guard let url = Bundle.main.url(forResource: resourceName, withExtension: resourceExt) else {
+func getBytes(resourceName: String, resourceExt: String=".riv", bundle: Bundle) -> [UInt8] {
+    guard let url = bundle.url(forResource: resourceName, withExtension: resourceExt) else {
         fatalError("Failed to locate \(resourceName) in bundle.")
     }
     guard let data = try? Data(contentsOf: url) else {
@@ -23,8 +23,8 @@ func getBytes(resourceName: String, resourceExt: String=".riv") -> [UInt8] {
 }
 
 @available(*, deprecated, message: "Use convenience init in RiveFile+Extensions instead")
-func getRiveFile(resourceName: String, resourceExt: String=".riv") throws -> RiveFile{
-    let byteArray = getBytes(resourceName: resourceName, resourceExt: resourceExt)
+func getRiveFile(resourceName: String, resourceExt: String=".riv", bundle: Bundle = .main) throws -> RiveFile{
+    let byteArray = getBytes(resourceName: resourceName, resourceExt: resourceExt, bundle: bundle)
     return try RiveFile(byteArray: byteArray)
 }
 

--- a/Source/Components/RiveModel.swift
+++ b/Source/Components/RiveModel.swift
@@ -18,8 +18,8 @@ open class RiveModel: ObservableObject {
         self.riveFile = riveFile
     }
     
-    public init(fileName: String) throws {
-        riveFile = try RiveFile(name: fileName)
+    public init(fileName: String, bundle: Bundle = .main) throws {
+        riveFile = try RiveFile(name: fileName, bundle: bundle)
     }
     
     public init(webURL: String, delegate: RiveFileDelegate) {

--- a/Source/Extensions/RiveFile+Extensions.swift
+++ b/Source/Extensions/RiveFile+Extensions.swift
@@ -9,13 +9,13 @@
 import Foundation
 
 public extension RiveFile {
-    convenience init(name fileName: String, extension ext: String = ".riv") throws {
-        let byteArray = RiveFile.getBytes(fileName: fileName, extension: ext)
+    convenience init(name fileName: String, extension ext: String = ".riv", bundle: Bundle = .main) throws {
+        let byteArray = RiveFile.getBytes(fileName: fileName, extension: ext, bundle: bundle)
         try self.init(byteArray: byteArray)
     }
     
-    static func getBytes(fileName: String, extension ext: String = ".riv") -> [UInt8] {
-        guard let url = Bundle.main.url(forResource: fileName, withExtension: ext) else {
+    static func getBytes(fileName: String, extension ext: String = ".riv", bundle: Bundle = .main) -> [UInt8] {
+        guard let url = bundle.url(forResource: fileName, withExtension: ext) else {
             fatalError("Failed to locate \(fileName) in bundle.")
         }
         guard let data = try? Data(contentsOf: url) else {


### PR DESCRIPTION
This PR adds a way to pass a user-provided `Bundle` (which defaults to `.main`)  when loading an animation from a file.

This is useful when loading files from a Swift Package Manager target (`.module` bundle) or from a library.