### PR TITLE
Fix riveModel force-unwrap crash

### DIFF
--- a/Source/RiveView.swift
+++ b/Source/RiveView.swift
@@ -11,7 +11,7 @@ import Foundation
 
 open class RiveView: RiveRendererView {
     // MARK: Configuration
-    internal weak var riveModel: RiveModel!
+    internal weak var riveModel: RiveModel?
     internal var fit: RiveFit = .contain { didSet { setNeedsDisplay() } }
     internal var alignment: RiveAlignment = .center { didSet { setNeedsDisplay() } }
     
@@ -157,11 +157,10 @@ open class RiveView: RiveRendererView {
         let wasPlaying = isPlaying
         eventQueue.fireAll()
         
-        if let stateMachine = riveModel.stateMachine {
+        if let stateMachine = riveModel?.stateMachine {
             isPlaying = stateMachine.advance(by: delta) && wasPlaying
             stateMachine.stateChanges().forEach { stateMachineDelegate?.stateMachine?(stateMachine, didChangeState: $0) }
-        }
-        else if let animation = riveModel.animation {
+        } else if let animation = riveModel?.animation {
             isPlaying = animation.advance(by: delta) && wasPlaying
             
             if isPlaying {
@@ -189,12 +188,12 @@ open class RiveView: RiveRendererView {
     /// This is called in the middle of drawRect
     override public func drawRive(_ rect: CGRect, size: CGSize) {
         // This prevents breaking when loading RiveFile async
-        guard riveModel.artboard != nil else { return }
+        guard let artboard = riveModel?.artboard else { return }
         
         let newFrame = CGRect(origin: rect.origin, size: size)
-        align(with: newFrame, contentRect: riveModel.artboard.bounds(), alignment: alignment, fit: fit)
-        draw(with: riveModel.artboard)
-
+        align(with: newFrame, contentRect: artboard.bounds(), alignment: alignment, fit: fit)
+        draw(with: artboard)
+        
         if let displayLink = displayLinkProxy?.displayLink {
             fpsCounter?.didDrawFrame(timestamp:displayLink.timestamp)
         }
@@ -237,8 +236,8 @@ open class RiveView: RiveRendererView {
         delegate delegateAction: ((RiveArtboard?, CGPoint)->Void)?,
         stateMachineAction: (RiveStateMachineInstance, CGPoint)->Void
     ) {
-        guard let artboard = riveModel.artboard else { return }
-        guard let stateMachine = riveModel.stateMachine else { return }
+        guard let artboard = riveModel?.artboard else { return }
+        guard let stateMachine = riveModel?.stateMachine else { return }
         let location = touch.location(in: self)
         
         let artboardLocation = artboardLocation(


### PR DESCRIPTION
The `RiveView` class has a [weak reference of the `riveModel`](https://github.com/rive-app/rive-ios/blob/3928a3ba2ef2e26ca081fb812e48f6d2786d0599/Source/RiveView.swift#L14) which is defined as implicitly unwrapped; the `RiveViewModel` stores both (the view and model) references strongly.

In certain circumstance the `riveModel` instance get's de-initialized before the `riveView`. This causes a crash in the [RiveView.advance(delta:) method](https://github.com/rive-app/rive-ios/blob/3928a3ba2ef2e26ca081fb812e48f6d2786d0599/Source/RiveView.swift#L160) when the property get's called and is nil:
<img width="1712" alt="Screenshot 2023-02-20 at 18 30 58" src="https://user-images.githubusercontent.com/42500484/220184363-985cf44d-dc9b-4f8f-9528-136f377db5e1.png">

I'm not 100% sure when this actually could happen, but I can constantly reproduce it by trying to present a view controller on a view controller that already presents one (you can see the log message in the screenshot above):
```swift
let riveViewController = RiveViewController()
present(riveViewController, animated: true)

DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
    let riveViewController2 = RiveViewController()
    self.present(riveViewController2, animated: true)
}
```
Here is an example project: [Rive Crash.zip](https://github.com/rive-app/rive-ios/files/10787315/Rive.Crash.zip)

It is generally a bad practice to do implicit/force unwraps so I fixed that and handled the optionals in all places!