### PR TITLE
Patch invalid texture size crash

### DIFF
--- a/Source/Renderer/RenderContextManager.mm
+++ b/Source/Renderer/RenderContextManager.mm
@@ -27,6 +27,14 @@
         }
         _metalQueue = [_metalDevice newCommandQueue];
         _depthStencilPixelFormat = MTLPixelFormatInvalid;
+        // See https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
+        if ([_metalDevice supportsFamily:MTLGPUFamilyApple3]) {
+            _maxTextureSize = 16384;
+        } else if ([_metalDevice supportsFamily:MTLGPUFamilyApple2]) {
+            _maxTextureSize = 8192;
+        } else {
+            _maxTextureSize = 4096; // See archive.org for older versions of the document.
+        }
         _framebufferOnly = NO;
 
         return self;

--- a/Source/Renderer/include/RenderContext.h
+++ b/Source/Renderer/include/RenderContext.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(strong) id<MTLDevice> metalDevice;
 @property(strong) id<MTLCommandQueue> metalQueue;
 @property MTLPixelFormat depthStencilPixelFormat;
+@property NSInteger maxTextureSize;
 @property BOOL framebufferOnly;
 - (rive::Factory*)factory;
 - (rive::Renderer*)beginFrame:(MTKView*)view;

--- a/Source/Renderer/rive_renderer_view.mm
+++ b/Source/Renderer/rive_renderer_view.mm
@@ -165,7 +165,15 @@
 
 - (void)drawInRect:(CGRect)rect withCompletion:(_Nullable MTLCommandBufferHandler)completionHandler
 {
-    if (CGRectGetWidth(rect) == 0 || CGRectGetHeight(rect) == 0)
+    CGSize drawableSize = self.drawableSize;
+    CGFloat width = drawableSize.width;
+    CGFloat height = drawableSize.height;
+    NSInteger maxSize = _renderContext.maxTextureSize;
+
+    // If `rect` has a zero size, `drawableSize` may have a `nan` size.
+    // If a parent view has a very small scale transform, `drawableSize` may exceed the maximum texture size.
+    // If a parent view has a zero scale transform, `drawableSize` may have an infinite size.
+    if (width == 0.0 || height == 0.0 || isnan(width) || isnan(height) || width > maxSize || height > maxSize)
     {
         return;
     }
@@ -179,7 +187,7 @@
     if (_renderer != nil)
     {
         _renderer->save();
-        [self drawRive:rect size:self.drawableSize];
+        [self drawRive:rect size:drawableSize];
         _renderer->restore();
     }
     [_renderContext endFrame:self withCompletion:completionHandler];


### PR DESCRIPTION
This is a quick fix for https://github.com/rive-app/rive-ios/issues/343

This fix does not address the fact that we could receive drawing requests with a very big drawable size in situations where it's not needed. A proper fix would probably be to either find a way to fix the computation of the drawable size, or disable automatic computation (`autoResizeDrawable = NO`) and compute it manually by converting the metal view bounds to window coordinates.