### PR TITLE
Patch to include RiveLogger in RiveRuntime.h

### DIFF
--- a/Source/Utils/RiveRuntime.h
+++ b/Source/Utils/RiveRuntime.h
@@ -17,6 +17,7 @@ FOUNDATION_EXPORT const unsigned char RiveRuntimeVersionString[];
 // In this header, you should import all the public headers of your framework
 // using statements like #import <RiveRuntime/PublicHeader.h>
 #import <RiveRuntime/Rive.h>
+#import <RiveRuntime/RiveLogger.h>
 #import <RiveRuntime/LayerState.h>
 #import <RiveRuntime/RiveFile.h>
 #import <RiveRuntime/RiveArtboard.h>


### PR DESCRIPTION
Context:
According to [Rive’s documentation on logging](https://rive.app/docs/runtimes/logging), developers should be able to use RiveLogger to debug animation state and transitions. However, when integrating Rive via Swift Package Manager (SPM), RiveLogger is not exposed to the consumer project, making it inaccessible in Xcode.

Fix:
Added #import <RiveRuntime/RiveLogger.h> to RiveRuntime.h to expose RiveLogger to SPM consumers.

This change allows developers using Rive via SPM to leverage Rive’s built-in logging capabilities as intended, without having to manually modify package internals or resort to workarounds.

Tested:
Confirmed that enabling logs with RiveLogger.isEnabled = true now compiles and outputs logs correctly in Xcode when integrated through SPM.