### PR TITLE
chore: ensure that calloc does not get called with overflowing value

### DIFF
--- a/Source/Renderer/RiveFile.mm
+++ b/Source/Renderer/RiveFile.mm
@@ -44,6 +44,10 @@
         UInt8* bytes;
         @try
         {
+            if (array.count > SIZE_MAX / sizeof(UInt64)) {
+                return nil;
+            }
+
             bytes = (UInt8*)calloc(array.count, sizeof(UInt64));
 
             [array enumerateObjectsUsingBlock:^(


### PR DESCRIPTION
`array.count*size(Uint64)` may overflow, resulting in a much lower allocation than necessary.