### PR TITLE
Expose APIs in RiveModel for KMP support

### DIFF
--- a/Source/RiveViewModel.swift
+++ b/Source/RiveViewModel.swift
@@ -618,7 +618,7 @@ import Combine
     
     /// Called by RiveFile when it finishes downloading an asset asynchronously
     @objc open func riveFileDidLoad(_ riveFile: RiveFile) throws {
-        riveModel = RiveModel(riveFile: riveFile)
+        riveModel = RiveModel(with: riveFile)
         
         sharedInit(
             artboardName: defaultModel.artboardName,


### PR DESCRIPTION
Expose RiveModel initializer to Objective-C for KMP interop

Added @objc(initWithRiveFile:) to RiveModel's initializer so it is visible
to Objective-C runtime. This allows Kotlin Multiplatform (via Kotlin/Native)
to construct RiveModel instances when bridging through Objective-C/Swift
APIs.

No functional changes for Swift consumers.
