### PR TITLE
fix: add @objc to touch methods in ViewModel examples

### DIFF
--- a/Example-iOS/Source/Examples/ViewModel/RiveButton.swift
+++ b/Example-iOS/Source/Examples/ViewModel/RiveButton.swift
@@ -23,18 +23,18 @@ class RiveButton: RiveViewModel {
             .frame(width: 100, height: 30)
     }
     
-    func touchBegan(onArtboard artboard: RiveArtboard?, atLocation location: CGPoint) {
+    @objc func touchBegan(onArtboard artboard: RiveArtboard?, atLocation location: CGPoint) {
         stop()
         setInput(input, value: true)
     }
     
-    func touchEnded(onArtboard artboard: RiveArtboard?, atLocation location: CGPoint) {
+    @objc func touchEnded(onArtboard artboard: RiveArtboard?, atLocation location: CGPoint) {
         stop()
         action?()
         touchCancelled(onArtboard: artboard, atLocation: location)
     }
     
-    func touchCancelled(onArtboard artboard: RiveArtboard?, atLocation location: CGPoint) {
+    @objc func touchCancelled(onArtboard artboard: RiveArtboard?, atLocation location: CGPoint) {
         setInput(input, value: false)
     }
 }

--- a/Example-iOS/Source/Examples/ViewModel/RiveSlider.swift
+++ b/Example-iOS/Source/Examples/ViewModel/RiveSlider.swift
@@ -21,11 +21,11 @@ class RiveSlider: RiveViewModel {
         super.init(fileName: "riveslider", stateMachineName: "Slide", fit: .scaleDown)
     }
     
-    func touchBegan(onArtboard artboard: RiveArtboard?, atLocation location: CGPoint) {
+    @objc func touchBegan(onArtboard artboard: RiveArtboard?, atLocation location: CGPoint) {
         touchMoved(onArtboard: artboard, atLocation: location)
     }
     
-    func touchMoved(onArtboard artboard: RiveArtboard?, atLocation location: CGPoint) {
+    @objc func touchMoved(onArtboard artboard: RiveArtboard?, atLocation location: CGPoint) {
         progress = Double(location.x / riveView!.frame.width) * 100
     }
 }


### PR DESCRIPTION
### Summary
The touch methods in the ViewModel example classes (`RiveSlider` and `RiveButton`) were not being called because they lacked the `@objc` attribute.

### Details
Since `RiveStateMachineDelegate` is an `@objc` protocol with optional methods, the runtime uses `respondsToSelector:` to check for implementation. In Swift, these methods must be explicitly marked with `@objc` (even if the class inherits from `NSObject`) to be visible to the Objective-C runtime for dynamic dispatch in this context.

Without this change, the slider and button in the "ViewModel Examples" section of the example app are non-functional.

### Affected Files
- [Example-iOS/Source/Examples/ViewModel/RiveSlider.swift](cci:7://file:///Users/leon/LeonDev/AppleDevelop/GithubProject/rive-ios/Example-iOS/Source/Examples/ViewModel/RiveSlider.swift:0:0-0:0)
- `Example-iOS/Source/Examples/ViewModel/RiveButton.swift`