### PR TITLE
fix: make Color properties public in experimental API

### DIFF
--- a/Source/Experimental/DataBinding/Color.swift
+++ b/Source/Experimental/DataBinding/Color.swift
@@ -43,7 +43,7 @@ public struct Color: Equatable {
         self.alpha = alpha
     }
     
-    public var argbValue: UInt32 {
+    var argbValue: UInt32 {
         return (UInt32(alpha) << 24) |
                (UInt32(red) << 16) |
                (UInt32(green) << 8) |


### PR DESCRIPTION
Make `red`, `green`, `blue`, and `alpha` properties public on the experimental `Color` struct. The struct and its initializers are already public, but the properties were internal, so consumers couldn't read color components back after creating or receiving a `Color`.