### PR TITLE
fix: emit empty strings through valueStream instead of throwing missingData

### DIFF
--- a/Source/Experimental/DataBinding/RiveViewModelInstanceData.mm
+++ b/Source/Experimental/DataBinding/RiveViewModelInstanceData.mm
@@ -87,11 +87,8 @@ RiveViewModelInstanceDataType RiveViewModelInstanceDataTypeFromCpp(
                 break;
             case rive::DataType::string:
             case rive::DataType::enumType:
-                if (!data.stringValue.empty())
-                {
-                    _stringValue = [NSString
-                        stringWithUTF8String:data.stringValue.c_str()];
-                }
+                _stringValue = [NSString
+                    stringWithUTF8String:data.stringValue.c_str()];
                 break;
             default:
                 // For other types, try stringValue if it's not empty


### PR DESCRIPTION
## Summary

Fixes #416 — `valueStream` throws `missingData` when a string property is set to `""`, permanently killing the listener.

The ObjC++ bridge in `RiveViewModelInstanceData.mm` was filtering out empty strings with `if (!data.stringValue.empty())`, leaving `_stringValue` as `nil`. The Swift layer then interpreted `nil` as missing data and terminated the stream.

The fix removes the `empty()` guard for `string`/`enumType` types so empty strings are correctly bridged as `@""`.

## Test plan

- [x] Added `test_value_withEmptyStringProperty_returnsEmptyString` — one-shot value request returns `""`
- [x] Added `test_valueStream_withEmptyStringProperty_yieldsEmptyString` — stream yields `""` without throwing
- [x] All existing ViewModelInstanceTests pass (36/36)