### PR TITLE
feat: add name() to experimental ViewModelInstance

### DIFF
--- a/Source/Experimental/CommandQueue/RiveCommandQueue.h
+++ b/Source/Experimental/CommandQueue/RiveCommandQueue.h
@@ -637,6 +637,15 @@ NS_SWIFT_NAME(CommandQueueProtocol)
                                requestID:(uint64_t)requestID;
 
 /**
+ * Requests the name of a view model instance.
+ *
+ * @param viewModelInstanceHandle The handle of the view model instance
+ * @param requestID The request ID for correlating the response
+ */
+- (void)requestViewModelInstanceName:(uint64_t)viewModelInstanceHandle
+                           requestID:(uint64_t)requestID;
+
+/**
  * Sets the string value of a view model property.
  *
  * @param viewModelInstanceHandle The handle of the view model instance

--- a/Source/Experimental/CommandQueue/RiveCommandQueue.mm
+++ b/Source/Experimental/CommandQueue/RiveCommandQueue.mm
@@ -681,6 +681,11 @@ public:
         std::string path,
         size_t size) override;
 
+    virtual void onViewModelInstanceNameReceived(
+        const rive::ViewModelInstanceHandle handle,
+        uint64_t requestId,
+        std::string name) override;
+
 private:
     __weak id<RiveViewModelInstanceListener> _observer;
 };
@@ -727,6 +732,21 @@ void _ViewModelInstanceListener::onViewModelListSizeReceived(
                               requestID:requestId
                                    path:nsPath
                                    size:static_cast<NSInteger>(size)];
+    }
+}
+
+void _ViewModelInstanceListener::onViewModelInstanceNameReceived(
+    const rive::ViewModelInstanceHandle handle,
+    uint64_t requestId,
+    std::string name)
+{
+    if (_observer)
+    {
+        NSString* nsName = [NSString stringWithUTF8String:name.c_str()];
+        [_observer
+            onViewModelInstanceNameReceived:reinterpret_cast<uint64_t>(handle)
+                                  requestID:requestId
+                                       name:nsName];
     }
 }
 
@@ -1745,6 +1765,16 @@ void _AudioListener::onAudioSourceDeleted(const rive::AudioSourceHandle handle,
       auto stdPath = std::string([path UTF8String]);
       self->_commandQueue->requestViewModelInstanceListSize(
           handle, stdPath, requestID);
+    }];
+}
+
+- (void)requestViewModelInstanceName:(uint64_t)viewModelInstanceHandle
+                           requestID:(uint64_t)requestID
+{
+    [self executeCommand:^{
+      auto handle = reinterpret_cast<rive::ViewModelInstanceHandle>(
+          viewModelInstanceHandle);
+      self->_commandQueue->requestViewModelInstanceName(handle, requestID);
     }];
 }
 

--- a/Source/Experimental/DataBinding/RiveViewModelInstanceListener.h
+++ b/Source/Experimental/DataBinding/RiveViewModelInstanceListener.h
@@ -52,6 +52,10 @@ NS_SWIFT_NAME(ViewModelInstanceListener)
                                path:(NSString*)path
                                size:(NSInteger)size;
 
+- (void)onViewModelInstanceNameReceived:(uint64_t)viewModelInstanceHandle
+                              requestID:(uint64_t)requestID
+                                   name:(NSString*)name;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/Experimental/DataBinding/ViewModelInstance.swift
+++ b/Source/Experimental/DataBinding/ViewModelInstance.swift
@@ -122,8 +122,24 @@ public class ViewModelInstance: Equatable {
         return lhs.viewModelInstanceHandle == rhs.viewModelInstanceHandle
     }
 
+    // MARK: - Name
+
+    /// Retrieves the name of this view model instance.
+    ///
+    /// The name is resolved from the C++ runtime via the command queue.
+    /// For named instances (created via `.name("myInstance", from:)`), this returns
+    /// the instance name as defined in the Rive file. For default or blank instances,
+    /// the name comes from the Rive file's default instance naming.
+    ///
+    /// - Returns: The name of this view model instance
+    /// - Throws: An error if the name cannot be retrieved
+    @MainActor
+    public func name() async throws -> String {
+        return try await dependencies.viewModelInstanceService.name(for: viewModelInstanceHandle)
+    }
+
     // MARK: - StringProperty
-    
+
     /// Retrieves the current value of a string property.
     ///
     /// - Parameter property: The string property to read


### PR DESCRIPTION
Add `name()` async method to `ViewModelInstance` in the experimental runtime, using the command queue round-trip. Depends on rive-app/rive-runtime#85.