### PR TITLE
fix: apply layout fit on initial RiveUIView setup

### DIFF
--- a/Source/Concurrency/View/RiveController.swift
+++ b/Source/Concurrency/View/RiveController.swift
@@ -193,28 +193,35 @@ final class RiveController {
 
     // MARK: - Private
 
+    func applyCurrentFit() {
+        if case .layout = rive.fit {
+            // Use the drawable (pixel) size, matching the advance path.
+            // `CommandQueue::setArtboardSize` divides by scale on the C++ side,
+            // so the caller must provide pixels — not view points — for
+            // `.layout(.automatic)` and `.explicit(N)` to size correctly.
+            let drawableSize = drawableSizeProvider() ?? .zero
+            let provider = scaleProvider() ?? FallbackScaleProvider()
+            let scale = rive.fit.bridged(from: provider).scaleFactor
+            RiveLog.debug(tag: .view, "[RiveUIView] Applying layout fit to artboard size: \(drawableSize) scale: \(scale)")
+            rive.artboard.setSize(drawableSize, scale: Float(scale))
+        } else {
+            RiveLog.debug(tag: .view, "[RiveUIView] Resetting artboard size for non-layout fit")
+            rive.artboard.resetSize()
+        }
+    }
+
     private func setupSubscriptions() {
         RiveLog.debug(tag: .view, "[RiveUIView] Setting up subscriptions")
+
+        // Catch fit values set before the controller existed (missed by the PassthroughSubject).
+        applyCurrentFit()
+
         rive
             .fitDidChange
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] fit in
-                guard let self else { return }
-                if case .layout = fit {
-                    RiveLog.debug(tag: .view, "[RiveUIView] Applying layout fit to artboard size")
-                    // Use the drawable (pixel) size, matching the advance path.
-                    // `CommandQueue::setArtboardSize` divides by scale on the C++ side,
-                    // so the caller must provide pixels — not view points — for
-                    // `.layout(.automatic)` and `.explicit(N)` to size correctly.
-                    let drawableSize = drawableSizeProvider() ?? .zero
-                    let provider = scaleProvider() ?? FallbackScaleProvider()
-                    let scale = fit.bridged(from: provider).scaleFactor
-                    rive.artboard.setSize(drawableSize, scale: Float(scale))
-                } else {
-                    RiveLog.debug(tag: .view, "[RiveUIView] Resetting artboard size for non-layout fit")
-                    rive.artboard.resetSize()
-                }
+            .sink { [weak self] _ in
+                self?.applyCurrentFit()
             }
             .store(in: &cancellables)
 

--- a/Source/Concurrency/View/RiveUIView.swift
+++ b/Source/Concurrency/View/RiveUIView.swift
@@ -350,6 +350,11 @@ public class RiveUIView: NativeView, MTKViewDelegate, ScaleProvider, DisplayLink
     }
 
     public func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
+        // Re-apply layout fit — drawable may have been zero when fit was first set.
+        if let rive, case .layout = rive.fit {
+            controller?.applyCurrentFit()
+        }
+
         // Drawable size changes (window resize, backing scale factor change) do
         // not otherwise trigger a draw when the MTKView is paused + uses
         // enableSetNeedsDisplay. Request a single redraw; the controller will

--- a/Tests/Concurrency/View/RiveControllerTests.swift
+++ b/Tests/Concurrency/View/RiveControllerTests.swift
@@ -724,6 +724,129 @@ final class RiveControllerTests: XCTestCase {
         XCTAssertEqual(fixture.commandQueue.advanceStateMachineCalls[1].time, 0)
     }
 
+    @MainActor
+    func test_init_appliesLayoutFitSetBeforeControllerCreated() async throws {
+        let (file, commandQueue, _, _) = await File.mock(fileHandle: 123)
+
+        let artboardService = ArtboardService(dependencies: .init(commandQueue: commandQueue))
+        let artboard = Artboard(
+            dependencies: .init(artboardService: artboardService),
+            artboardHandle: 42
+        )
+
+        let stateMachineService = StateMachineService(dependencies: .init(commandQueue: commandQueue))
+        let stateMachine = StateMachine(
+            dependencies: .init(stateMachineService: stateMachineService),
+            stateMachineHandle: 123
+        )
+
+        let rive = try await Rive(
+            file: file,
+            artboard: artboard,
+            stateMachine: stateMachine,
+            dataBind: .none
+        )
+
+        // Set layout fit BEFORE controller exists (simulates the bug scenario)
+        rive.fit = .layout(scaleFactor: .automatic)
+
+        let controller = RiveController(
+            rive: rive,
+            drawableSizeProvider: { CGSize(width: 320, height: 240) },
+            scaleProvider: { MockScaleProvider() }
+        )
+        _ = controller // silence unused warning
+
+        // The controller should have applied the current layout fit on init,
+        // calling setArtboardSize even though the fitDidChange event was missed.
+        XCTAssertEqual(commandQueue.setArtboardSizeCalls.count, 1)
+        XCTAssertEqual(commandQueue.setArtboardSizeCalls.first?.width, 320)
+        XCTAssertEqual(commandQueue.setArtboardSizeCalls.first?.height, 240)
+    }
+
+    @MainActor
+    func test_init_appliesLayoutFitFromRiveInit() async throws {
+        let (file, commandQueue, _, _) = await File.mock(fileHandle: 123)
+
+        let artboardService = ArtboardService(dependencies: .init(commandQueue: commandQueue))
+        let artboard = Artboard(
+            dependencies: .init(artboardService: artboardService),
+            artboardHandle: 42
+        )
+
+        let stateMachineService = StateMachineService(dependencies: .init(commandQueue: commandQueue))
+        let stateMachine = StateMachine(
+            dependencies: .init(stateMachineService: stateMachineService),
+            stateMachineHandle: 123
+        )
+
+        // Pass layout fit directly in Rive init
+        let rive = try await Rive(
+            file: file,
+            artboard: artboard,
+            stateMachine: stateMachine,
+            dataBind: .none,
+            fit: .layout(scaleFactor: .automatic)
+        )
+
+        let controller = RiveController(
+            rive: rive,
+            drawableSizeProvider: { CGSize(width: 400, height: 300) },
+            scaleProvider: { MockScaleProvider() }
+        )
+        _ = controller
+
+        // The controller should apply the layout fit on init even though
+        // no fitDidChange event was ever published (fit was set in Rive.init).
+        XCTAssertEqual(commandQueue.setArtboardSizeCalls.count, 1)
+        XCTAssertEqual(commandQueue.setArtboardSizeCalls.first?.width, 400)
+        XCTAssertEqual(commandQueue.setArtboardSizeCalls.first?.height, 300)
+    }
+
+    @MainActor
+    func test_applyCurrentFit_updatesArtboardSizeWhenBoundsChange() async throws {
+        let (file, commandQueue, _, _) = await File.mock(fileHandle: 123)
+
+        let artboardService = ArtboardService(dependencies: .init(commandQueue: commandQueue))
+        let artboard = Artboard(
+            dependencies: .init(artboardService: artboardService),
+            artboardHandle: 42
+        )
+
+        let stateMachineService = StateMachineService(dependencies: .init(commandQueue: commandQueue))
+        let stateMachine = StateMachine(
+            dependencies: .init(stateMachineService: stateMachineService),
+            stateMachineHandle: 123
+        )
+
+        let rive = try await Rive(
+            file: file,
+            artboard: artboard,
+            stateMachine: stateMachine,
+            dataBind: .none,
+            fit: .layout(scaleFactor: .automatic)
+        )
+
+        var currentDrawableSize = CGSize.zero
+        let controller = RiveController(
+            rive: rive,
+            drawableSizeProvider: { currentDrawableSize },
+            scaleProvider: { MockScaleProvider() }
+        )
+
+        // Initial call had zero drawable size
+        XCTAssertEqual(commandQueue.setArtboardSizeCalls.count, 1)
+        XCTAssertEqual(commandQueue.setArtboardSizeCalls.first?.width, 0)
+
+        // Simulate drawable size becoming available (e.g. drawableSizeWillChange)
+        currentDrawableSize = CGSize(width: 402, height: 400)
+        controller.applyCurrentFit()
+
+        XCTAssertEqual(commandQueue.setArtboardSizeCalls.count, 2)
+        XCTAssertEqual(commandQueue.setArtboardSizeCalls.last?.width, 402)
+        XCTAssertEqual(commandQueue.setArtboardSizeCalls.last?.height, 400)
+    }
+
     // MARK: - Helpers
 
     @MainActor


### PR DESCRIPTION
## Summary

Fixes #443 — `.layout` fit mode not applied when set during `Rive()` init or immediately after creating `RiveUIView`.

`RiveController` subscribes to `fitDidChange` (`PassthroughSubject`) but missed events fired before the controller was created. Now applies the current fit immediately on controller init, and re-applies when drawable size changes (handles zero-bounds at startup).

## Screenshots

| Bug: initial render (zoomed/cropped) | Fix: initial render (correct) |
|---|---|
| <img width="300" alt="bug-layout-not-applied-on-init" src="https://github.com/user-attachments/assets/deeb64d2-a754-4da7-be75-ac2df31d4459" /> | <img width="300" alt="fix-layout-applied-on-init" src="https://github.com/user-attachments/assets/8a3bb57a-8700-4b4f-b899-94506fa73eaf" /> |
| `.layout` set in init but NOT applied | With fix, layout applied from the start |

## Test plan

- [x] New unit tests: `test_init_appliesLayoutFitSetBeforeControllerCreated`, `test_init_appliesLayoutFitFromRiveInit`, `test_applyCurrentFit_updatesArtboardSizeWhenBoundsChange`
- [x] All existing `RiveControllerTests` pass
- [x] Visual verification on iPhone 16 simulator (iOS 18.6)