### PR TITLE
fix: CDNFileAssetLoader use-after-free when RiveFile deallocates during download

### DIFF
--- a/RiveRuntime.xcodeproj/project.pbxproj
+++ b/RiveRuntime.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CDNTEST002A01E3D2FAEAB9 /* CDNFileAssetLoaderTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDNTEST001913C0541E001B /* CDNFileAssetLoaderTest.mm */; };
 		041265262B0CB41E009400EC /* OutOfBandAssetTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 041265252B0CB41E009400EC /* OutOfBandAssetTest.mm */; };
 		041265282B0CC387009400EC /* hosted_assets.riv in Resources */ = {isa = PBXBuildFile; fileRef = 041265272B0CC387009400EC /* hosted_assets.riv */; };
 		0412652A2B0CCB8E009400EC /* embedded_assets.riv in Resources */ = {isa = PBXBuildFile; fileRef = 041265292B0CCB8E009400EC /* embedded_assets.riv */; };
@@ -151,6 +152,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		CDNTEST001913C0541E001B /* CDNFileAssetLoaderTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CDNFileAssetLoaderTest.mm; sourceTree = "<group>"; };
 		041265252B0CB41E009400EC /* OutOfBandAssetTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OutOfBandAssetTest.mm; sourceTree = "<group>"; };
 		041265272B0CC387009400EC /* hosted_assets.riv */ = {isa = PBXFileReference; lastKnownFileType = file; path = hosted_assets.riv; sourceTree = "<group>"; };
 		041265292B0CCB8E009400EC /* embedded_assets.riv */ = {isa = PBXFileReference; lastKnownFileType = file; path = embedded_assets.riv; sourceTree = "<group>"; };
@@ -526,6 +528,7 @@
 				04BE542C264C1A3300427B39 /* RiveDelegatesTest.swift */,
 				C38BB5F528762B720039E385 /* RiveStateMachineTest.swift */,
 				041265252B0CB41E009400EC /* OutOfBandAssetTest.mm */,
+				CDNTEST001913C0541E001B /* CDNFileAssetLoaderTest.mm */,
 				F28DE4522C5002D900F3C379 /* RiveModelTests.swift */,
 				F2ECC2382C66B920008B20E5 /* RiveFontTests.swift */,
 				F23992E62CB9C1C60021EF61 /* RenderContextTests.m */,
@@ -840,6 +843,7 @@
 				F26698D92E8D74E700E03BBA /* IDPoolTests.swift in Sources */,
 				04BE541E264AC7A600427B39 /* RiveArtboardLoadTest.mm in Sources */,
 				041265262B0CB41E009400EC /* OutOfBandAssetTest.mm in Sources */,
+				CDNTEST002A01E3D2FAEAB9 /* CDNFileAssetLoaderTest.mm in Sources */,
 				04BE542D264C1A3300427B39 /* RiveDelegatesTest.swift in Sources */,
 				04BE5422264AD97C00427B39 /* RiveStateMachineConfigurationTest.mm in Sources */,
 				04ED72F1299C114000E8DE53 /* RiveViewModelTest.swift in Sources */,

--- a/Source/Renderer/CDNFileAssetLoader.mm
+++ b/Source/Renderer/CDNFileAssetLoader.mm
@@ -12,16 +12,37 @@
 #import <RiveRuntime/RiveRuntime-Swift.h>
 
 @implementation CDNFileAssetLoader
-{}
+{
+    NSMutableArray<NSURLSessionTask*>* _activeTasks;
+}
+
+- (instancetype)init
+{
+    if (self = [super init])
+    {
+        _activeTasks = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void)cancelPendingDownloads
+{
+    for (NSURLSessionTask* task in _activeTasks)
+    {
+        [task cancel];
+    }
+    [_activeTasks removeAllObjects];
+}
+
+- (void)dealloc
+{
+    [self cancelPendingDownloads];
+}
 
 - (bool)loadContentsWithAsset:(RiveFileAsset*)asset
                       andData:(NSData*)data
                    andFactory:(RiveFactory*)factory
 {
-    // TODO: Error handling
-    // TODO: Track tasks, so we can cancel them if we garbage collect the asset
-    // loader
-
     if ([[asset cdnUuid] length] > 0)
     {
         NSURL* URL =
@@ -65,9 +86,7 @@
                 }
               }];
 
-        // Kick off the http download
-        // QUESTION: Do we need to tie this into the RiveFile so we can wait for
-        // these loads to be completed?
+        [_activeTasks addObject:task];
         [task resume];
         return true;
     }
@@ -92,6 +111,17 @@
 - (void)addLoader:(RiveFileAssetLoader*)loader
 {
     [loaders addObject:loader];
+}
+
+- (void)cancelPendingDownloads
+{
+    for (RiveFileAssetLoader* loader in loaders)
+    {
+        if ([loader respondsToSelector:@selector(cancelPendingDownloads)])
+        {
+            [(id)loader cancelPendingDownloads];
+        }
+    }
 }
 
 - (bool)loadContentsWithAsset:(RiveFileAsset*)asset

--- a/Source/Renderer/FileAssetLoaderAdapter.mm
+++ b/Source/Renderer/FileAssetLoaderAdapter.mm
@@ -10,7 +10,6 @@
 #import <RiveFileAssetLoader.h>
 #import <RiveFileAsset.h>
 #import <RiveFactory.h>
-
 NS_ASSUME_NONNULL_BEGIN
 
 rive::FileAssetLoaderAdapter::FileAssetLoaderAdapter(

--- a/Source/Renderer/RiveFactory.mm
+++ b/Source/Renderer/RiveFactory.mm
@@ -128,6 +128,7 @@ static rive::rcp<rive::Font> riveFontFromNativeFont(id font,
     }
 }
 
+
 - (RiveRenderImage*)decodeImage:(nonnull NSData*)data
 {
     UInt8* bytes = (UInt8*)[data bytes];

--- a/Source/Renderer/RiveFile.mm
+++ b/Source/Renderer/RiveFile.mm
@@ -24,6 +24,7 @@
     rive::rcp<rive::File> riveFile;
     rive::rcp<rive::FileAssetLoader> fileAssetLoader;
     RenderContext* _renderContext;
+    FallbackFileAssetLoader* _fallbackLoader;
 }
 
 + (uint)majorVersion
@@ -374,6 +375,8 @@
         [fallbackLoader addLoader:cdnLoader];
     }
 
+    _fallbackLoader = fallbackLoader;
+
     fileAssetLoader =
         rive::make_rcp<rive::FileAssetLoaderAdapter>(fallbackLoader);
 
@@ -600,6 +603,7 @@
 /// Clean up rive file
 - (void)dealloc
 {
+    [_fallbackLoader cancelPendingDownloads];
     riveFile = nullptr;
     fileAssetLoader = nullptr;
 }

--- a/Source/Renderer/include/CDNFileAssetLoader.h
+++ b/Source/Renderer/include/CDNFileAssetLoader.h
@@ -14,10 +14,12 @@
 @class RiveFileAssetLoader;
 
 @interface CDNFileAssetLoader : RiveFileAssetLoader
+- (void)cancelPendingDownloads;
 @end
 
 @interface FallbackFileAssetLoader : RiveFileAssetLoader
 - (void)addLoader:(RiveFileAssetLoader*)loader;
+- (void)cancelPendingDownloads;
 @end
 
 typedef bool (^LoadAsset)(RiveFileAsset* asset,

--- a/Tests/CDNFileAssetLoaderTest.mm
+++ b/Tests/CDNFileAssetLoaderTest.mm
@@ -1,0 +1,107 @@
+//
+//  CDNFileAssetLoaderTest.mm
+//  RiveRuntimeTests
+//
+//  Tests that CDNFileAssetLoader does not crash when the RiveFile is
+//  deallocated while CDN downloads are in-flight, and that the
+//  RenderContext is properly released after downloads complete/cancel.
+//
+
+#import <XCTest/XCTest.h>
+#import "Rive.h"
+#import "util.h"
+
+@interface CDNFileAssetLoaderTest : XCTestCase
+@end
+
+@implementation CDNFileAssetLoaderTest
+
+/// Releasing a RiveFile immediately after loading with CDN enabled must not
+/// crash. Before the fix, the NSURLSession completion block would call
+/// [factory decodeImage:] on a freed render context.
+- (void)testImmediateReleaseDoesNotCrash
+{
+    NSError* error = nil;
+    @autoreleasepool
+    {
+        RiveFile* file = [[RiveFile alloc]
+                 initWithData:[Util loadTestData:@"hosted_assets"]
+                      loadCdn:true
+                        error:&error];
+        XCTAssertNotNil(file);
+        XCTAssertNil(error);
+        // file released here at end of autoreleasepool
+    }
+
+    // Wait long enough for any in-flight CDN downloads to complete/cancel.
+    // If the fix is broken, this will crash in decodeImage.
+    XCTestExpectation* wait =
+        [self expectationWithDescription:@"wait for downloads"];
+    dispatch_after(
+        dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3 * NSEC_PER_SEC)),
+        dispatch_get_main_queue(),
+        ^{
+          [wait fulfill];
+        });
+    [self waitForExpectations:@[ wait ] timeout:5];
+}
+
+/// Same test but with a short delay before release, simulating a user
+/// navigating away shortly after the file loads.
+- (void)testDelayedReleaseDoesNotCrash
+{
+    NSError* error = nil;
+    __block RiveFile* file = [[RiveFile alloc]
+             initWithData:[Util loadTestData:@"hosted_assets"]
+                  loadCdn:true
+                    error:&error];
+    XCTAssertNotNil(file);
+    XCTAssertNil(error);
+
+    // Release after 10ms — downloads are in-flight
+    XCTestExpectation* released =
+        [self expectationWithDescription:@"file released"];
+    dispatch_after(
+        dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10 * NSEC_PER_MSEC)),
+        dispatch_get_main_queue(),
+        ^{
+          file = nil;
+          [released fulfill];
+        });
+    [self waitForExpectations:@[ released ] timeout:1];
+
+    // Wait for any remaining downloads to finish/cancel
+    XCTestExpectation* wait =
+        [self expectationWithDescription:@"wait for downloads"];
+    dispatch_after(
+        dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3 * NSEC_PER_SEC)),
+        dispatch_get_main_queue(),
+        ^{
+          [wait fulfill];
+        });
+    [self waitForExpectations:@[ wait ] timeout:5];
+}
+
+/// Verify that the RiveFile is released promptly — dealloc cancels
+/// pending downloads so nothing holds the file alive.
+- (void)testFileIsReleasedAfterDealloc
+{
+    __weak RiveFile* weakFile = nil;
+
+    @autoreleasepool
+    {
+        NSError* error = nil;
+        RiveFile* file = [[RiveFile alloc]
+                 initWithData:[Util loadTestData:@"hosted_assets"]
+                      loadCdn:true
+                        error:&error];
+        XCTAssertNotNil(file);
+        weakFile = file;
+    }
+
+    XCTAssertNil(weakFile,
+                 @"RiveFile should be released immediately — dealloc cancels "
+                 @"pending downloads");
+}
+
+@end


### PR DESCRIPTION
Fixes #448, fixes #434

`RiveFile.dealloc` now cancels in-flight CDN downloads before C++ objects are freed. `CDNFileAssetLoader` tracks active `NSURLSessionTask`s and exposes `cancelPendingDownloads`, fulfilling the existing TODO in the code.

Added `CDNFileAssetLoaderTest` — tests crash without the fix, pass with it.