### PR TITLE
[DRAFT/CI PILOT] Run iOS tests on self-hosted Mac mini (tart) fleet

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run_tests:
     name: Run Rive tests
-    runs-on: ghcr.io/cirruslabs/macos-runner:sequoia
+    runs-on: [self-hosted, macOS, ARM64, tart]
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Do not merge — CI runner pilot

Relabels the iOS test job from `cirruslabs/macos-runner:sequoia` to the self-hosted **Tart Mac mini fleet**.

Purpose: validate iOS/visionOS/tvOS/Catalyst simulator builds + iOS tests on the minis. **Expected to surface the `sudo xcodes select 16.4` gap** — the fleet image ships Xcode 26.5, not 16.4. This tells us whether the iOS category needs a second Xcode on the runners.

No signing/notarization/publishing in this workflow (simulator builds + tests only).

**To restore Cirrus:** revert the `runs-on` line.