### PR TITLE
ci: migrate macOS CI from Cirrus to the tart mini fleet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
 
   build_framework:
     name: Create RiveRuntime.xcframework
-    runs-on: warp-macos-26-arm64-12x
+    runs-on: [self-hosted, macOS, ARM64, tart]
     needs: [determine_version]
     outputs:
       checksum: ${{steps.get_checksum.outputs.checksum}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
 
   build_framework:
     name: Create RiveRuntime.xcframework
-    runs-on: [self-hosted, macOS, ARM64, tart]
+    runs-on: warp-macos-26-arm64-12x
     needs: [determine_version]
     outputs:
       checksum: ${{steps.get_checksum.outputs.checksum}}
@@ -84,8 +84,16 @@ jobs:
           sudo mv premake5 /usr/local/bin
           pip3 install ply
 
-      - name: Select Xcode 26.5
-        run: sudo xcodes select 26.5
+      - name: Select Xcode 26
+        run: |
+          if command -v xcodes >/dev/null 2>&1; then
+            sudo xcodes select 26.5
+          else
+            APP=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+            echo "xcodes not found; selecting $APP"
+            sudo xcode-select -s "$APP/Contents/Developer"
+          fi
+          xcodebuild -version
 
       - name: Install all Xcode platforms
         run: xcodebuild -downloadAllPlatforms

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
 
   build_framework:
     name: Create RiveRuntime.xcframework
-    runs-on: ghcr.io/cirruslabs/macos-runner:sequoia
+    runs-on: [self-hosted, macOS, ARM64, tart]
     needs: [determine_version]
     outputs:
       checksum: ${{steps.get_checksum.outputs.checksum}}
@@ -84,9 +84,9 @@ jobs:
           sudo mv premake5 /usr/local/bin
           pip3 install ply
 
-      - name: Select Xcode 16.4
-        run: sudo xcodes select 16.4
-      
+      - name: Select Xcode 26.5
+        run: sudo xcodes select 26.5
+
       - name: Install all Xcode platforms
         run: xcodebuild -downloadAllPlatforms
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run_tests:
     name: Run Rive tests
-    runs-on: ghcr.io/cirruslabs/macos-runner:sequoia
+    runs-on: [self-hosted, macOS, ARM64, tart]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -41,8 +41,8 @@ jobs:
           sudo mv premake5 /usr/local/bin
           pip3 install ply
 
-      - name: Select Xcode 16.4
-        run: sudo xcodes select 16.4
+      - name: Select Xcode 26.5
+        run: sudo xcodes select 26.5
 
       - name: Build for iOS Simulator (using the cache, we should make an archive of course)
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run_tests:
     name: Run Rive tests
-    runs-on: [self-hosted, macOS, ARM64, tart]
+    runs-on: warp-macos-26-arm64-12x
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -41,8 +41,16 @@ jobs:
           sudo mv premake5 /usr/local/bin
           pip3 install ply
 
-      - name: Select Xcode 26.5
-        run: sudo xcodes select 26.5
+      - name: Select Xcode 26
+        run: |
+          if command -v xcodes >/dev/null 2>&1; then
+            sudo xcodes select 26.5
+          else
+            APP=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+            echo "xcodes not found; selecting $APP"
+            sudo xcode-select -s "$APP/Contents/Developer"
+          fi
+          xcodebuild -version
 
       - name: Build for iOS Simulator (using the cache, we should make an archive of course)
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run_tests:
     name: Run Rive tests
-    runs-on: warp-macos-26-arm64-12x
+    runs-on: [self-hosted, macOS, ARM64, tart]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -57,6 +57,12 @@ jobs:
           ./scripts/build.sh ios_sim release
 
       - name: Test iOS runtime
+        # xcpretty parses xcodebuild output through a Ruby regex that throws on
+        # non-ASCII bytes when the locale is US-ASCII; the tart image doesn't set a
+        # UTF-8 LANG, so set it here (matches the rive repo's iossim test job).
+        env:
+          LANG: en_US.UTF-8
+          LC_ALL: en_US.UTF-8
         run: ./scripts/test.sh ios_sim
 
       - name: Build for visionOS Simulator (using the cache, we should make an archive of course)


### PR DESCRIPTION
Moves the macOS jobs off the paid Cirrus `macos-runner:sequoia` image onto the self-hosted Tart mini fleet, matching the rive repo migration (Cirrus is being retired).

**Changed**
- `tests.yml` `run_tests` → `[self-hosted, macOS, ARM64, tart]`
- `release.yml` `build_framework` → `[self-hosted, macOS, ARM64, tart]`
- Xcode select `16.4` → `26.5` (the tahoe image's version)

`build_framework` builds an **unsigned** xcframework (no signing secrets); `do_release`/`publish_cocoapods` stay on ubuntu/macos-14.

> [!IMPORTANT]
> **Blocked on runner-group access.** rive-ios must be added to the org runner group that holds the minis (Org Settings → Actions → Runner groups → Repository access → add `rive-ios`). Until then the `tart` job cannot acquire a runner ("job was not acquired by Runner of type self-hosted"). No code change needed once granted — just re-run.